### PR TITLE
Fix Issue # 195 : BaseValidationRule.assertValid(String context, String ...

### DIFF
--- a/src/main/java/org/owasp/esapi/HTTPUtilities.java
+++ b/src/main/java/org/owasp/esapi/HTTPUtilities.java
@@ -528,14 +528,14 @@ public interface HTTPUtilities
      * Note that the header "pragma: no-cache" is intended only for use in HTTP requests, not HTTP responses. However, Microsoft has chosen to
      * directly violate the standards, so we need to include that header here. For more information, please refer to the relevant standards:
      * <UL>
-     * <LI><a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html">HTTP/1.1 Cache-Control "no-cache"</a>
-     * <LI><a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1">HTTP/1.1 Cache-Control "no-store"</a>
-     * <LI><a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.2">HTTP/1.0 Pragma "no-cache"</a>
-     * <LI><a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.32">HTTP/1.0 Expires</a>
-     * <LI><a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.21">IE6 Caching Issues</a>
-     * <LI><a href="http://support.microsoft.com/kb/937479">Firefox browser.cache.disk_cache_ssl</a>
+     * <LI><a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.1">HTTP/1.1 Cache-Control "no-cache"</a>
+     * <LI><a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.2">HTTP/1.1 Cache-Control "no-store"</a>
+     * <LI><a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.32">HTTP/1.0 Pragma "no-cache"</a>
+     * <LI><a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.21">HTTP/1.0 Expires</a>
+     * <LI><a href="http://support.microsoft.com/kb/937479">IE6 Caching Issues</a>
      * <LI><a href="http://support.microsoft.com/kb/234067">Microsoft directly violates specification for pragma: no-cache</a>
-     * <LI><a href="http://www.mozilla.org/quality/networking/docs/netprefs.html">Mozilla</a>
+     * <LI><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Mozilla_networking_preferences#Cache">Firefox browser.cache.disk_cache_ssl</a>
+     * <LI><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Preferences/Mozilla_networking_preferences">Mozilla</a>
      * </UL>
      *
      * @param response

--- a/src/main/java/org/owasp/esapi/crypto/CipherTextSerializer.java
+++ b/src/main/java/org/owasp/esapi/crypto/CipherTextSerializer.java
@@ -302,7 +302,7 @@ public class CipherTextSerializer {
             
             debug("convertToCipherText: kdfPrf = " + kdfPrf + ", kdfVers = " + kdfVers);
             if ( ! versionIsCompatible( kdfVers) ) {
-            	throw new EncryptionException("This version of ESAPI does is not compatible with the version of ESAPI that encrypted your data.",
+            	throw new EncryptionException("This version of ESAPI is not compatible with the version of ESAPI that encrypted your data.",
             			"KDF version " + kdfVers + " from serialized ciphertext not compatibile with current KDF version of " + 
             			KeyDerivationFunction.kdfVersion);
             }

--- a/src/main/java/org/owasp/esapi/reference/DefaultHTTPUtilities.java
+++ b/src/main/java/org/owasp/esapi/reference/DefaultHTTPUtilities.java
@@ -811,7 +811,7 @@ public class DefaultHTTPUtilities implements org.owasp.esapi.HTTPUtilities {
     public void sendRedirect(HttpServletResponse response, String location) throws AccessControlException, IOException {
         if (!ESAPI.validator().isValidRedirectLocation("Redirect", location, false)) {
             logger.fatal(Logger.SECURITY_FAILURE, "Bad redirect location: " + location);
-            throw new IOException("Redirect failed");
+            throw new AccessControlException("Redirect failed");
         }
         response.sendRedirect(location);
     }

--- a/src/main/java/org/owasp/esapi/reference/validation/BaseValidationRule.java
+++ b/src/main/java/org/owasp/esapi/reference/validation/BaseValidationRule.java
@@ -100,7 +100,7 @@ public abstract class BaseValidationRule implements ValidationRule {
 		try {
 			valid = getValid( context, input );
 		} catch (ValidationException e) {
-			if( errorList == null { 
+			if( errorList == null) { 
 				throw e;
 			} else {
 				errorList.addError(context, e);

--- a/src/main/java/org/owasp/esapi/reference/validation/BaseValidationRule.java
+++ b/src/main/java/org/owasp/esapi/reference/validation/BaseValidationRule.java
@@ -89,7 +89,7 @@ public abstract class BaseValidationRule implements ValidationRule {
      * {@inheritDoc}
 	 */
 	public void assertValid( String context, String input ) throws ValidationException {
-		getValid( context, input, null );
+		getValid( context, input );
 	}
 
     /**
@@ -100,7 +100,11 @@ public abstract class BaseValidationRule implements ValidationRule {
 		try {
 			valid = getValid( context, input );
 		} catch (ValidationException e) {
-			errorList.addError(context, e);
+			if( errorList == null { 
+				throw e;
+			} else {
+				errorList.addError(context, e);
+			}
 		}
 		return valid;
 	}


### PR DESCRIPTION
...input) causes NPE if input is not valid.

Made changes as required, also getvalid(string,string) should be called instead.
Could not test the changes.
Let me know if the error persists.
Contact : karansanwal@gmail.com