### PR TITLE
Fix for issue #289

### DIFF
--- a/src/main/java/org/owasp/esapi/filters/ClickjackFilter.java
+++ b/src/main/java/org/owasp/esapi/filters/ClickjackFilter.java
@@ -95,8 +95,8 @@ public class ClickjackFilter implements Filter
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException
 	{
         HttpServletResponse res = (HttpServletResponse)response;
-        chain.doFilter(request, response);
         res.addHeader("X-FRAME-OPTIONS", mode );
+        chain.doFilter(request, response);
 	}
 
 	/**


### PR DESCRIPTION
https://github.com/ESAPI/esapi-java-legacy/issues/289

When using ClickJackFilter, In some cases response header is not set.
http://stackoverflow.com/questions/11371755/clickjacking-filter-to-add-x-frame-options-in-response