### PR TITLE
Fixes #345 -  JUnit test failure in ValidatorTest.testIsValidDate()

### DIFF
--- a/src/test/java/org/owasp/esapi/reference/ValidatorTest.java
+++ b/src/test/java/org/owasp/esapi/reference/ValidatorTest.java
@@ -323,7 +323,7 @@ public class ValidatorTest extends TestCase {
     public void testIsValidDate() {
         System.out.println("isValidDate");
         Validator instance = ESAPI.validator();
-        DateFormat format = SimpleDateFormat.getDateInstance();
+        DateFormat format = SimpleDateFormat.getDateInstance(SimpleDateFormat.MEDIUM, Locale.US);
         assertTrue(instance.isValidDate("datetest1", "September 11, 2001", format, true));
         assertFalse(instance.isValidDate("datetest2", null, format, false));
         assertFalse(instance.isValidDate("datetest3", "", format, false));


### PR DESCRIPTION
PROBLEM

The org.owasp.esapi.errors.ValidationException is thrown with a logMessage:

    Invalid date: context=datetest1, 
    format=java.text.SimpleDateFormat@2aca24a9, input=September 11, 2001

and a detailMessage:

    datetest1: Invalid date must follow the java.text.DecimalFormat@674dc
    format

CAUSE

The SimpleDateFormat.getDateInstance() is default locale dependent, so
the date September 11, 2001 can't be correctly formatted on my Java Virtual
Machine Locale which is it_IT.

SOLUTION

Use the US locale.

Fixes ESAPI/esapi-java-legacy#345