### PR TITLE
Fix issue 355 by adding a call to file.deleteOnExit().

### DIFF
--- a/src/main/java/org/owasp/esapi/waf/internal/InterceptingServletOutputStream.java
+++ b/src/main/java/org/owasp/esapi/waf/internal/InterceptingServletOutputStream.java
@@ -56,7 +56,10 @@ public class InterceptingServletOutputStream extends ServletOutputStream {
 		 * the prefix and suffix small for less processing. The "oew" is intended
 		 * to stand for "OWASP ESAPI WAF" and the "hop" for HTTP output.
 		 */
-		this.out = new RandomAccessFile ( File.createTempFile("oew", ".hop"), "rw" ); 
+		File tempFile= File.createTempFile("oew", ".hop");
+		this.out = new RandomAccessFile (tempFile, "rw" ); 
+		tempFile.deleteOnExit();
+		
 	}
 
 	public void reset() throws IOException {


### PR DESCRIPTION
Fixes issue 355 by adding tempFile.deleteOnExit() in InterceptingServletOutputStream.
This only works for a clean vm exit.

If robustness is required I can redo it following the implementation  [here](http://stackoverflow.com/questions/16691437/when-are-java-temporary-files-deleted/16694493#16694493)