### PR TITLE
Packages the esapi.tld into the jar file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,8 +250,16 @@
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>configuration/META-INF</directory>
+                <targetPath>META-INF</targetPath>
+            </resource>
+    </resources>
     </build>
 
     <reporting>


### PR DESCRIPTION
```
    <resources>
        <resource>
            <directory>configuration/META-INF</directory>
            <targetPath>META-INF</targetPath>
        </resource>
    </resources>
```

The above packages all files in `configuration/META-INF`  (currently only esapi.tld) to the `META-INF` dir in jar file.
This however, causes files in `src/main/resources` (ESAPI-properties.xsd) to be ignored.

```
    <resources>
        <resource>
            <directory>src/main/resources</directory>
        </resource>
        <resource>
            <directory>configuration/META-INF</directory>
            <targetPath>META-INF</targetPath>
        </resource>
    </resources>
```

The above fixes issue #365 and all related issues.
