### PR TITLE
Integer overflow in for loop

### DIFF
--- a/src/main/java/org/owasp/esapi/crypto/CipherText.java
+++ b/src/main/java/org/owasp/esapi/crypto/CipherText.java
@@ -668,7 +668,7 @@ public final class CipherText implements Serializable {
      */
     public byte[] getSeparateMAC() {
         if ( separate_mac_ == null ) {
-            return null;
+            return new byte[0];
         }
         byte[] copy = new byte[ separate_mac_.length ];
         System.arraycopy(separate_mac_, 0, copy, 0, separate_mac_.length);

--- a/src/main/java/org/owasp/esapi/crypto/CipherTextSerializer.java
+++ b/src/main/java/org/owasp/esapi/crypto/CipherTextSerializer.java
@@ -104,6 +104,7 @@ public class CipherTextSerializer {
         int ciphertextLen = rawCiphertext.length;
         assert ciphertextLen >= 1 : "Raw ciphertext length must be >= 1 byte.";
         byte[] mac = cipherText_.getSeparateMAC();
+        assert mac.length > 0 : "MAC lenght is zero";
         assert mac.length < Short.MAX_VALUE :
                             "MAC length too large. Max is " + Short.MAX_VALUE;
         short macLen = (short) mac.length;

--- a/src/main/java/org/owasp/esapi/filters/RequestRateThrottleFilter.java
+++ b/src/main/java/org/owasp/esapi/filters/RequestRateThrottleFilter.java
@@ -37,7 +37,7 @@ public class RequestRateThrottleFilter implements Filter
 
     private int hits = 5;
 
-    private int period = 10;
+    private long period = 10;
 
     private static final String HITS = "hits";
 

--- a/src/main/java/org/owasp/esapi/reference/DefaultSecurityConfiguration.java
+++ b/src/main/java/org/owasp/esapi/reference/DefaultSecurityConfiguration.java
@@ -1067,8 +1067,8 @@ public class DefaultSecurityConfiguration implements SecurityConfiguration {
 	 * {@inheritDoc}
 	 */
     public long getRememberTokenDuration() {
-        int days = getESAPIProperty( REMEMBER_TOKEN_DURATION, 14 );
-        return (long) (1000 * 60 * 60 * 24 * days);
+        long days = getESAPIProperty( REMEMBER_TOKEN_DURATION, 14 );
+        return (1000 * 60 * 60 * 24 * days);
     }
 
     /**

--- a/src/main/java/org/owasp/esapi/waf/internal/InterceptingServletOutputStream.java
+++ b/src/main/java/org/owasp/esapi/waf/internal/InterceptingServletOutputStream.java
@@ -117,7 +117,7 @@ public class InterceptingServletOutputStream extends ServletOutputStream {
 				
 				byte[] buff = new byte[FLUSH_BLOCK_SIZE];
 				
-				for(int i=0;i<out.length();) {
+				for(long i=0;i<out.length();) {
 					
 					long currentPos = out.getFilePointer();
 					long totalSize = out.length();

--- a/src/main/java/org/owasp/esapi/waf/rules/BeanShellRule.java
+++ b/src/main/java/org/owasp/esapi/waf/rules/BeanShellRule.java
@@ -109,6 +109,8 @@ public class BeanShellRule extends Rule {
 		while( (line=br.readLine()) != null ) {
 			sb.append(line + System.getProperty("line.separator"));
 		}
+
+		br.close();
 		
 		return sb.toString();
 	}


### PR DESCRIPTION
Fix a theoretical CWE-190 integer overflow as out.length is a long ([RandomAccessFile](https://docs.oracle.com/javase/8/docs/api/index.html?java/io/RandomAccessFile.html)) while the for loop is indexed by an int
