### PR TITLE
Support of Cookie without maxAge set

### DIFF
--- a/src/main/java/org/owasp/esapi/filters/SecurityWrapperResponse.java
+++ b/src/main/java/org/owasp/esapi/filters/SecurityWrapperResponse.java
@@ -124,7 +124,9 @@ public class SecurityWrapperResponse extends HttpServletResponseWrapper implemen
         // Set-Cookie:<name>=<value>[; <name>=<value>][; expires=<date>][;
         // domain=<domain_name>][; path=<some_path>][; secure][;HttpOnly
         String header = name + "=" + value;
-        header += "; Max-Age=" + maxAge;
+        if (maxAge >= 0) {
+            header += "; Max-Age=" + maxAge;
+        }
         if (domain != null) {
             header += "; Domain=" + domain;
         }

--- a/src/main/java/org/owasp/esapi/reference/DefaultHTTPUtilities.java
+++ b/src/main/java/org/owasp/esapi/reference/DefaultHTTPUtilities.java
@@ -340,7 +340,9 @@ public class DefaultHTTPUtilities implements org.owasp.esapi.HTTPUtilities {
         // Set-Cookie:<name>=<value>[; <name>=<value>][; expires=<date>][;
         // domain=<domain_name>][; path=<some_path>][; secure][;HttpOnly]
         String header = name + "=" + value;
-        header += "; Max-Age=" + maxAge;
+		if (maxAge >= 0) {
+			header += "; Max-Age=" + maxAge;
+		}
         if (domain != null) {
             header += "; Domain=" + domain;
         }


### PR DESCRIPTION
The DefaultHttpUtilities and SecurityWrapperResponse add systematically a Max-Age to the HTTP Header when adding a cookie. Even if the cookie has a negative maxAge value (which is the default value).

So when adding a "session" cookie (without Max-Age), ESAPI add a Max-Age=-1 in the HTTP Header and the cookie will be discarded by the browser, because it is invalid (http://www.ietf.org/rfc/rfc2109.txt).
Wen the maxAge field of the cookie is negative, it should not be specified at HTTP Header level.
