### PR TITLE
Issue #389

### DIFF
--- a/src/main/java/org/owasp/esapi/Encoder.java
+++ b/src/main/java/org/owasp/esapi/Encoder.java
@@ -369,7 +369,7 @@ public interface Encoder {
 	String encodeForOS(Codec codec, String input);
 
 	/**
-	 * Encode data for use in LDAP queries.
+	 * Encode data for use in LDAP queries. Wildcard (*) characters will be encoded.
 	 * 
 	 * @param input 
 	 * 		the text to encode for LDAP
@@ -378,6 +378,18 @@ public interface Encoder {
 	 */
 	String encodeForLDAP(String input);
 
+	/**
+	 * Encode data for use in LDAP queries. You have the option whether or not to encode wildcard (*) characters.
+	 * 
+	 * @param input 
+	 * 		the text to encode for LDAP
+	 * @param encodeWildcards 
+	 *      whether or not wildcard (*) characters will be encoded.
+     *
+	 * @return input encoded for use in LDAP
+	 */
+	String encodeForLDAP(String input, boolean encodeWildcards);
+	 
 	/**
 	 * Encode data for use in an LDAP distinguished name.
 	 * 

--- a/src/main/java/org/owasp/esapi/reference/DefaultEncoder.java
+++ b/src/main/java/org/owasp/esapi/reference/DefaultEncoder.java
@@ -287,7 +287,7 @@ public class DefaultEncoder implements Encoder {
 	/**
 	 * {@inheritDoc}
 	 */
-	public String encodeForLDAP(String input, boolean escapeWildcards) {
+	public String encodeForLDAP(String input, boolean encodeWildcards) {
 	    if( input == null ) {
 	    	return null;	
 	    }
@@ -299,7 +299,7 @@ public class DefaultEncoder implements Encoder {
 			if (c == '\\') {
 	            sb.append("\\5c");
 	        }
-	        else if ((c == '*') && escapeWildcards) {
+	        else if ((c == '*') && encodeWildcards) {
 	            sb.append("\\2a");
 	        }
 	        else if (c == '(') {

--- a/src/main/java/org/owasp/esapi/reference/DefaultEncoder.java
+++ b/src/main/java/org/owasp/esapi/reference/DefaultEncoder.java
@@ -281,6 +281,13 @@ public class DefaultEncoder implements Encoder {
 	 * {@inheritDoc}
 	 */
 	public String encodeForLDAP(String input) {
+		return encodeForLDAP(input, true);
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	public String encodeForLDAP(String input, boolean escapeWildcards) {
 	    if( input == null ) {
 	    	return null;	
 	    }
@@ -288,25 +295,25 @@ public class DefaultEncoder implements Encoder {
 	    StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < input.length(); i++) {
 			char c = input.charAt(i);
-			switch (c) {
-			case '\\':
-				sb.append("\\5c");
-				break;
-			case '*':
-				sb.append("\\2a");
-				break;
-			case '(':
-				sb.append("\\28");
-				break;
-			case ')':
-				sb.append("\\29");
-				break;
-			case '\0':
-				sb.append("\\00");
-				break;
-			default:
-				sb.append(c);
-			}
+
+			if (c == '\\') {
+	            sb.append("\\5c");
+	        }
+	        else if ((c == '*') && escapeWildcards) {
+	            sb.append("\\2a");
+	        }
+	        else if (c == '(') {
+	            sb.append("\\28");
+	        }
+	        else if (c == ')') {
+	            sb.append("\\29");
+	        }
+	        else if (c == '\0') {
+	            sb.append("\\00");
+	        }
+	        else {
+	            sb.append(c);
+	        }
 		}
 		return sb.toString();
 	}

--- a/src/test/java/org/owasp/esapi/reference/EncoderTest.java
+++ b/src/test/java/org/owasp/esapi/reference/EncoderTest.java
@@ -471,7 +471,19 @@ public class EncoderTest extends TestCase {
     }
     
     /**
-	 * Test of encodeForLDAP method, of class org.owasp.esapi.Encoder.
+	 * Test of encodeForLDAP method with without encoding wildcard characters, of class org.owasp.esapi.Encoder.
+	 */
+    public void testEncodeForLDAPWithoutEncodingWildcards() {
+        System.out.println("encodeForLDAPWithoutEncodingWildcards");
+        Encoder instance = ESAPI.encoder();
+        assertEquals(null, instance.encodeForLDAP(null, false));
+        assertEquals("No special characters to escape", "Hi This is a test #��", instance.encodeForLDAP("Hi This is a test #��", false));
+        assertEquals("Zeros", "Hi \\00", instance.encodeForLDAP("Hi \u0000", false));
+        assertEquals("LDAP Christams Tree", "Hi \\28This\\29 = is * a \\5c test # � � �", instance.encodeForLDAP("Hi (This) = is * a \\ test # � � �", false));
+    }
+    
+    /**
+	 * Test of encodeForDN method, of class org.owasp.esapi.Encoder.
 	 */
     public void testEncodeForDN() {
         System.out.println("encodeForDN");


### PR DESCRIPTION
Overloaded the encodeForLDAP method to provide the option of not
encoding wildcard (*) characters.

This would be used when doing queries against an LDAP directory using
wildcards, while at the same time, encoding other potentially dangerous
characters.