### PR TITLE
Issue #376 -- Addressed Kevin Wall's CR comments.

### DIFF
--- a/src/main/java/org/owasp/esapi/Validator.java
+++ b/src/main/java/org/owasp/esapi/Validator.java
@@ -694,6 +694,8 @@ public interface Validator {
 	 * the kind of regex required for subsequent validation to mitigate regex-based 
 	 * DoS attacks.  
 	 * 
+	 * @see <a href="https://www.ietf.org/rfc/rfc3986.txt">https://www.ietf.org/rfc/rfc3986.txt</a>
+	 * 
  	 *	@param context
 	 *  		A descriptive name of the parameter that you are validating (e.g., LoginPage_UsernameField). This value is used by any logging or error handling that is done with respect to the value passed in.
 	 *  @param input

--- a/src/main/java/org/owasp/esapi/reference/DefaultValidator.java
+++ b/src/main/java/org/owasp/esapi/reference/DefaultValidator.java
@@ -1307,10 +1307,8 @@ public class DefaultValidator implements org.owasp.esapi.Validator {
 		Set<UriSegment> set = parseMap.keySet();
 		
 		SecurityConfiguration sg = ESAPI.securityConfiguration();
-//		boolean restrictMixed = sg.getBooleanProp("AllowMixedEncoding");
-//		boolean restrictMultiple = sg.getBooleanProp("AllowMultipleEncoding");
-		boolean allowMixed = sg.getAllowMixedEncoding();
-		boolean allowMultiple = sg.getAllowMultipleEncoding();
+		boolean allowMixed = sg.getBooleanProp("Encoder.AllowMixedEncoding");
+		boolean allowMultiple = sg.getBooleanProp("Encoder.AllowMultipleEncoding");
 		for(UriSegment seg: set){
 			String value = encoder.canonicalize(parseMap.get(seg), allowMultiple, allowMixed);
 			value = value == null ? "" : value;

--- a/src/main/java/org/owasp/esapi/reference/DefaultValidator.java
+++ b/src/main/java/org/owasp/esapi/reference/DefaultValidator.java
@@ -66,6 +66,7 @@ import org.owasp.esapi.reference.validation.StringValidationRule;
  *
  * @author Jeff Williams (jeff.williams .at. aspectsecurity.com) <a href="http://www.aspectsecurity.com">Aspect Security</a>
  * @author Jim Manico (jim@manico.net) <a href="http://www.manico.net">Manico.net</a>
+ * @author Matt Seil (mseil .at. acm.org) 
  *
  * @since June 1, 2007
  * @see org.owasp.esapi.Validator
@@ -1208,14 +1209,15 @@ public class DefaultValidator implements org.owasp.esapi.Validator {
 	 */
 	public boolean isValidURI(String context, String input, boolean allowNull) {
 		boolean isValid = false;
-		URI compliantURI = this.getRfcCompliantURI(input);
+		boolean inputIsNullOrEmpty = input == null || "".equals(input);
 		
 		try{
-			if(null != compliantURI){
+			URI compliantURI = null == input ? new URI("") :  this.getRfcCompliantURI(input);
+			if(null != compliantURI && input != null){
 				String canonicalizedURI = getCanonicalizedURI(compliantURI);
 				//if getCanonicalizedURI doesn't throw an IntrusionException, then the URI contains no mixed or 
 				//double-encoding attacks.  
-				logger.info(Logger.SECURITY_SUCCESS, "We did not detect any mixed or multiple encoding in the uri:[" + input + "]");
+				logger.debug(Logger.SECURITY_SUCCESS, "We did not detect any mixed or multiple encoding in the uri:[" + input + "]");
 				Validator v = ESAPI.validator();
 				//This part will use the regex from validation.properties.  This regex should be super-simple, and 
 				//used mainly to restrict certain parts of a URL.  
@@ -1224,11 +1226,17 @@ public class DefaultValidator implements org.owasp.esapi.Validator {
 				//and if the URI has any queries that also happen to match HTML entities, like &para;
 				//it will cease conforming to the regex we now specify for a URL.
 				isValid = p.matcher(canonicalizedURI).matches();
+			}else{
+				if(allowNull && inputIsNullOrEmpty ){
+					isValid = true;
+				}
 			}
 			
 		}catch (IntrusionException e){
 			logger.error(Logger.SECURITY_FAILURE, e.getMessage());
 			isValid = false;
+		} catch (URISyntaxException e) {
+			logger.error(Logger.EVENT_FAILURE, e.getMessage());
 		}
 		
 		
@@ -1249,11 +1257,14 @@ public class DefaultValidator implements org.owasp.esapi.Validator {
 	}
 	
 	/**
-	 * This does alot.  This will extract each piece of a URI according to parse zone, and it will construct 
-	 * a canonicalized String representing a version of the URI that is safe to run regex against to it. 
+	 * {@inheritDoc}
+	 * 
+	 * This will extract each piece of a URI according to parse zone as specified in <a href="https://www.ietf.org/rfc/rfc3986.txt">RFC-3986</a> section 3, 
+	 * and it will construct a canonicalized String representing a version of the URI that is safe to 
+	 * run regex against. 
 	 * 
 	 * @param dirtyUri
-	 * @return
+	 * @return Canonicalized URI string.
 	 * @throws IntrusionException
 	 */
 	public String getCanonicalizedURI(URI dirtyUri) throws IntrusionException{

--- a/src/test/java/org/owasp/esapi/reference/ValidatorTest.java
+++ b/src/test/java/org/owasp/esapi/reference/ValidatorTest.java
@@ -1156,7 +1156,27 @@ public class ValidatorTest extends TestCase {
     	assertFalse(v.isValidURI("test", "http://core-jenkins.scansafe.cisco.com/佐贺诺伦-^ńörén.jpg", false));
     }
     
+    public void testGetValidUriNullInput(){
+    	Validator v = ESAPI.validator();
+    	boolean isValid = v.isValidURI("test", null, true);
+    	assertTrue(isValid);
+    }
+    
     public void testGetCanonicalizedUri() throws Exception {
+    	Validator v = ESAPI.validator();
+    	
+    	String expectedUri = "http://palpatine@foo bar.com/path_to/resource?foo=bar#frag";
+    	//Please note that section 3.2.1 of RFC-3986 explicitly states not to encode
+    	//password information as in http://palpatine:password@foo.com, and this will
+    	//not appear in the userinfo field.  
+    	String input = "http://palpatine@foo%20bar.com/path_to/resource?foo=bar#frag";
+    	URI uri = new URI(input);
+    	System.out.println(uri.toString());
+    	assertEquals(expectedUri, v.getCanonicalizedURI(uri));
+    	
+    }
+    
+    public void testGetCanonicalizedUriWithMailto() throws Exception {
     	Validator v = ESAPI.validator();
     	
     	String expectedUri = "http://palpatine@foo bar.com/path_to/resource?foo=bar#frag";

--- a/src/test/resources/urisForTest.txt
+++ b/src/test/resources/urisForTest.txt
@@ -1,3 +1,4 @@
+#Format is URI,Expected test value
 https://127.0.0.1:8080/foo/bar,TRUE
 http://shareasale.com:8080/sem/fusce.xml?sed=sodales&tristique=scelerisque,TRUE
 http://shareasale.com/sem/fusce.xml?sed=sodales&tristique=scelerisque,TRUE


### PR DESCRIPTION
> Matt,
>
> As promised; sorry I didn't get to this earlier. I will be gone remainder of
> today and tomorrow so if you have questions they may not get answered
> until Tuesday.
>
> Anyway, just a few minor comments. While they look numerous, this is probably
> only a 1/2 or so of clean-up, so it's not as bad as it looks. But overall,
> looks solid. Thanks for the contribution.
>
> Validator.java - looks good. Maybe just add a hypertext link in the Javadoc for
>     RFC 3986 to the IETF RFC page.
>
> DefaultValidator.java -
>     1) Maybe add your name as author? (We all know you touched it last
> anyhow!  :)

Done.  Will be in next commit.  
…

>     2) in isValidURI(), if 'allowNull' is 'true' and 'input' is null, then
>        unless I'm missing something, I don't think this does what the
> documentation
>        in Valid.isValidURI() claims that it should do. I think you need to check
>        this condition before calling getRcfCompliantURI() at line 1211, because
>        the CTOR for URI will throw an NPE (which is ignored) and null returned
>        and I think that you would like to distinguish that exception (which is a
>        valid case if 'allowNull' is 'true') from URISyntaxException.

Nice catch, and *bad matt*.  I didn't write any tests around those conditions.  Will be in next commit.  
…

>     3) I would consider changing the logging statement at line 1218 from 'info'
>        to 'debug' level.
Done.
…

>     4) Probably want to consider other catchs for Exceptions at line 1233. E.g.,
>        specifically, I'm thinking that we cannot be 100% sure that the regex
>        pattern for the Validator.URL in validation.properties is a valid one so
>        I think we at least need to handle those gracefully. And they certainly
>        should not just be treated as IntrusionExceptions as more likely someone
>        just fat-fingered the custom regex and failed to balance ()s or whatever.

I think the failure for a bad regex to happen should happen back in the beginning when we first bring in those regexs in the first place.  I just toyed with making the URL pattern "(((" and I don't see any errors or exceptions... and I'm also pretty sure that I've seen an open issue that we allow people to enter invalid regexes.  

The only way I could validate that the regex isn't bad here would be to manually compile a regex... and for multiple reasons I don't want to do that.  Should we open a new feature request to validate regex syntax on bootup?
…

>     5) Leading sentence in Javadoc comment at line 1252 needs changed. In the
>        generated javadoc, the summary sentence is the first sentence in the
>        javadoc comment, so the summary statement for
> DefaultValidator.getCanonicalizedURI()
>        will be "This does alot.", which is not all that informative. I think
>        (but am not 100% sure & am too lazy to look it up) that you can start out
>        with '{@inheritDoc}' in the javadoc comment and then add comments
>        afterwards, but if not, it would be better to just copy what you have
>        from Validator.getCanonicalizedURI() and *then* add what you have after
>        the lead-in statements....because 'This does alot' doesn't really "say a
>        lot"! :) Also, rather than referring to "parse zone" in the javadoc
>        comment, you should at LEAST refer to RFC 3986 section 3 and maybe link
>        to it.

Done, and done.  
…

>     6) Lines 1301 & 1302 should really be replaced with the commented out lines,
>        1299-1300 because the others have been deprecated IIRC. Not a big deal,
>        but we need to start compiling with '-Xlint'. If I haven't committed that
>        change already, then I probably have it in my private build that I have
>        not yet committed. That will result in a rather substantial cleanup
>        effort though. We probably should need to have a new ConfigPropNames
>        class though to put all the property names though so we don't have to
>        hard code them all over the place.

So, full disclosure:  When I do it without the deprecated methods, it flat out breaks, and I don't know why.  Basically we get exceptions to the effect that AllowMultipleEncoding and AllowMixedEncoding aren't present, and I *can* verify that there's only one copy of ESAPI.properties being used, and that the values ARE there.  Because I'm lazy, I would like to defer the problem until deprecation means "kill it with fire!"  But if you insist I can take the time and try and figure out why it won't work.  
…

>     7) I know that the 'userinfo' part of 'authority' is deprecated, but does
>        that mean it is no longer valid? If it's not, then it's presence would
>        be invalid, but if deprecated has the traditional meaning of "we're
>        getting rid of this in the not-to-distant future, but well tolerate it
>        for now", then I think think additional logic is needed in the
> buildUrl() method
>        to handle logic around userinfo that is currently just ignored.
> Specifically
>        (and I may be mistaken here; been a long time since I've read the RFCs),
>        the 'userinfo' part of the 'authority' segment URI is only
> valid for certain
>        'schemes' (e.g., ftp(s), http(s), IIRC, but not things like 'file' or
>        'mailto') that probably needs to be taken into account somewhere. Also,
>        this also makes me realize that our Validator.URL regex only works with
>        http(s) and ftp(s) schemes, but not things like 'mailto', 'file', 'git',
>        etc. schemes. Should we consider this? At a mininim, it seems like we
>        should call this out somewhere in the documentation.
>

Userinfo isn't deprecated, but user:password as userinfo IS.  That said, the canonicalization API works on it for mailto.  I just scanned the entire RFC 3986 for "userinfo" references, and the only guidance it gives is that "some schemes don't have userinfo" but it provides zero information as to what those cases are.  How do you want to handle this?  Do you know any schemes where userinfo is illegal?


…
I put a comment in urisForTest.txt that describes the basic format of the data... "URI,Expected Test Value"

I think that would bypass any confusion and prevent me from needing to do any rewrites for the parsing of the file...  what do you think?

I'll add some other schemes to account for missing authorities.  