### PR TITLE
Updated pom.xml so the base compile version is 1.7 instead of 1.6.  T…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,8 +219,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                     <debug>true</debug>
                     <showWarnings>true</showWarnings>
                     <showDeprecation>false</showDeprecation>


### PR DESCRIPTION
…his eliminates incompatibilities with mvn site that was preventing newer plugins from using items like java.util.Function.