### PR TITLE
Issue #292 && Issue #403 -- Updated default regex size for jsessionid…

### DIFF
--- a/src/test/java/org/owasp/esapi/reference/DefaultSecurityConfigurationTest.java
+++ b/src/test/java/org/owasp/esapi/reference/DefaultSecurityConfigurationTest.java
@@ -12,6 +12,7 @@ import java.util.regex.Pattern;
 import org.junit.Test;
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.Logger;
+import org.owasp.esapi.SecurityConfiguration;
 import org.owasp.esapi.errors.ConfigurationException;
 import org.owasp.esapi.reference.DefaultSecurityConfiguration.DefaultSearchPath;
 
@@ -436,5 +437,43 @@ public class DefaultSecurityConfigurationTest {
 		int expected = 6;
 		int testValue = DefaultSearchPath.values().length;
 		assertEquals(expected, testValue);
+	}
+	
+	@Test
+	public void defaultPropertiesTest(){
+		SecurityConfiguration sc = ESAPI.securityConfiguration();
+//		# Maximum size of JSESSIONID for the application--the validator regex may have additional values.  
+//		HttpUtilities.HTTPJSESSIONIDLENGTH=50
+		assertEquals(50, sc.getIntProp("HttpUtilities.HTTPJSESSIONIDLENGTH"));
+//		# Maximum length of a URL (see https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers)
+//		HttpUtilities.URILENGTH=2000
+		assertEquals(2000, sc.getIntProp("HttpUtilities.URILENGTH"));
+//		# Maximum length for an http scheme
+//		HttpUtilities.HTTPSCHEMELENGTH=10
+		assertEquals(10, sc.getIntProp("HttpUtilities.HTTPSCHEMELENGTH"));
+//		# Maximum length for an http host
+//		HttpUtilities.HTTPHOSTLENGTH=100
+		assertEquals(100, sc.getIntProp("HttpUtilities.HTTPHOSTLENGTH"));
+//		# Maximum length for an http path
+//		HttpUtilities.HTTPPATHLENGTH=150
+		assertEquals(150, sc.getIntProp("HttpUtilities.HTTPPATHLENGTH"));
+//		#Maximum length for a context path 
+//		HttpUtilities.contextPathLength=150
+		assertEquals(150, sc.getIntProp("HttpUtilities.contextPathLength"));
+//		#Maximum length for an httpServletPath 
+//		HttpUtilities.HTTPSERVLETPATHLENGTH=100
+		assertEquals(100, sc.getIntProp("HttpUtilities.HTTPSERVLETPATHLENGTH"));
+//		#Maximum length for an http query parameter name
+//		HttpUtilities.httpQueryParamNameLength=100
+		assertEquals(100, sc.getIntProp("HttpUtilities.httpQueryParamNameLength"));
+//		#Maximum length for an http query parameter -- old default was 2000, but that's the max length for a URL...
+//		HttpUtilities.httpQueryParamValueLength=500
+		assertEquals(500, sc.getIntProp("HttpUtilities.httpQueryParamValueLength"));
+//		# Maximum size of HTTP header key--the validator regex may have additional values. 
+//		HttpUtilities.MaxHeaderNameSize=256
+		assertEquals(256, sc.getIntProp("HttpUtilities.MaxHeaderNameSize"));
+//		# Maximum size of HTTP header value--the validator regex may have additional values. 
+//		HttpUtilities.MaxHeaderValueSize=4096
+		assertEquals(4096, sc.getIntProp("HttpUtilities.MaxHeaderValueSize"));
 	}
 }

--- a/src/test/java/org/owasp/esapi/reference/ValidatorTest.java
+++ b/src/test/java/org/owasp/esapi/reference/ValidatorTest.java
@@ -1082,7 +1082,7 @@ public class ValidatorTest extends TestCase {
         request.addHeader("p1", "login");
         request.addHeader("f1", "<A HREF=\"http://0x42.0x0000066.0x7.0x93/\">XSS</A>");
         request.addHeader("p2", TestUtils.generateStringOfLength(200));   // Upper limit increased from 150 -> 200, GitHub issue #351
-        request.addHeader("f2", TestUtils.generateStringOfLength(201));
+        request.addHeader("f2", TestUtils.generateStringOfLength(4097));
         assertEquals(safeRequest.getHeader("p1"), request.getHeader("p1"));
         assertEquals(safeRequest.getHeader("p2"), request.getHeader("p2"));
         assertFalse(safeRequest.getHeader("f1").equals(request.getHeader("f1")));

--- a/src/test/resources/esapi/ESAPI.properties
+++ b/src/test/resources/esapi/ESAPI.properties
@@ -331,10 +331,28 @@ HttpUtilities.ForceHttpOnlySession=false
 HttpUtilities.ForceSecureSession=false
 HttpUtilities.ForceHttpOnlyCookies=true
 HttpUtilities.ForceSecureCookies=true
-# Maximum size of HTTP header key
+# Maximum size of HTTP header key--the validator regex may have additional values. 
 HttpUtilities.MaxHeaderNameSize=256
-# Maximum size of HTTP header value
+# Maximum size of HTTP header value--the validator regex may have additional values. 
 HttpUtilities.MaxHeaderValueSize=4096
+# Maximum size of JSESSIONID for the application--the validator regex may have additional values.  
+HttpUtilities.HTTPJSESSIONIDLENGTH=50
+# Maximum length of a URL (see https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers)
+HttpUtilities.URILENGTH=2000
+# Maximum length for an http scheme
+HttpUtilities.HTTPSCHEMELENGTH=10
+# Maximum length for an http host
+HttpUtilities.HTTPHOSTLENGTH=100
+# Maximum length for an http path
+HttpUtilities.HTTPPATHLENGTH=150
+#Maximum length for a context path 
+HttpUtilities.contextPathLength=150
+#Maximum length for an httpServletPath 
+HttpUtilities.HTTPSERVLETPATHLENGTH=100
+#Maximum length for an http query parameter name
+HttpUtilities.httpQueryParamNameLength=100
+#Maximum length for an http query parameter -- old default was 2000, but that's the max length for a URL...
+HttpUtilities.httpQueryParamValueLength=500
 # File upload configuration
 HttpUtilities.ApprovedUploadExtensions=.zip,.pdf,.doc,.docx,.ppt,.pptx,.tar,.gz,.tgz,.rar,.war,.jar,.ear,.xls,.rtf,.properties,.java,.class,.txt,.xml,.jsp,.jsf,.exe,.dll
 HttpUtilities.MaxUploadFileBytes=500000000
@@ -455,7 +473,8 @@ Validator.HTTPHeaderValue=^[a-zA-Z0-9()\\-=\\*\\.\\?;,+\\/:&_ ]*$
 Validator.HTTPServletPath=^[a-zA-Z0-9.\\-\\/_]*$
 Validator.HTTPPath=^[a-zA-Z0-9.\\-_]*$
 Validator.HTTPURL=^.*$
-Validator.HTTPJSESSIONID=^[A-Z0-9]{10,30}$
+Validator.HTTPJSESSIONID=^[A-Z0-9]{10,32}$
+
 
 # Contributed by Fraenku@gmx.ch
 # Googlecode Issue 116 (http://code.google.com/p/owasp-esapi-java/issues/detail?id=116)


### PR DESCRIPTION
… from 30 to 32, and refactored related classes to NOT use magic numbers.'

@kwwall -- I need to add a second commit.  It's a bridge too far I think to get the httpRequest object fully unit tested prior to the pending release, but we can write unit tests to make sure that we can pull back expected properties so that we don't run into runtime issues.  For all the new properties I've added in the past couple weeks, I'll make sure they're all tested in `DefaultSecurityConfigurationTest`.  I know it seems pedantic to test properties, we're still releasing our properties files to the public, and we need to make sure that if we fat-finger or change anything, that it won't break things for people.  