### PR TITLE
Fix configuration loading: Use value instead of constants also update vulnerable dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.3.2</version>
+            <version>1.3.3</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -185,14 +185,14 @@
             <version>1.2.10</version>
         </dependency>
         <dependency>
-            <groupId>org.beanshell</groupId>
-            <artifactId>bsh-core</artifactId>
-            <version>2.0b4</version>
+            <groupId>org.apache-extras.beanshell</groupId>
+			<artifactId>bsh</artifactId>
+			<version>2.0b6</version>
         </dependency>
         <dependency>
             <groupId>org.owasp.antisamy</groupId>
             <artifactId>antisamy</artifactId>
-            <version>1.5.6</version>
+            <version>1.5.7</version>
         </dependency>
         <!-- The following is only a TRANSITIVE dependency used by antisamy.
              Antisamy uses 2.7.0, which has unpatched vulnerability

--- a/src/main/java/org/owasp/esapi/reference/DefaultSecurityConfiguration.java
+++ b/src/main/java/org/owasp/esapi/reference/DefaultSecurityConfiguration.java
@@ -647,31 +647,31 @@ public class DefaultSecurityConfiguration implements SecurityConfiguration {
 					// try resourceDirectory folder
 					if (in == null) {
 						currentClasspathSearchLocation = resourceDirectory + "/";
-						in = currentLoader.getResourceAsStream(DefaultSearchPath.RESOURCE_DIRECTORY + fileName);
+						in = currentLoader.getResourceAsStream(DefaultSearchPath.RESOURCE_DIRECTORY.value() + fileName);
 					}
 
 					// try .esapi folder. Look here first for backward compatibility.
 					if (in == null) {
 						currentClasspathSearchLocation = ".esapi/";
-						in = currentLoader.getResourceAsStream(DefaultSearchPath.DOT_ESAPI + fileName);
+						in = currentLoader.getResourceAsStream(DefaultSearchPath.DOT_ESAPI.value() + fileName);
 					} 
 					
 					// try esapi folder (new directory)
 					if (in == null) {
 						currentClasspathSearchLocation = "esapi/";
-						in = currentLoader.getResourceAsStream(DefaultSearchPath.ESAPI + fileName);
+						in = currentLoader.getResourceAsStream(DefaultSearchPath.ESAPI.value() + fileName);
 					} 
 					
 					// try resources folder
 					if (in == null) {
 						currentClasspathSearchLocation = "resources/";
-						in = currentLoader.getResourceAsStream(DefaultSearchPath.RESOURCES + fileName);
+						in = currentLoader.getResourceAsStream(DefaultSearchPath.RESOURCES.value() + fileName);
 					}
 					
 					// try src/main/resources folder
 					if (in == null) {
 						currentClasspathSearchLocation = "src/main/resources/";
-						in = currentLoader.getResourceAsStream(DefaultSearchPath.SRC_MAIN_RESOURCES + fileName);
+						in = currentLoader.getResourceAsStream(DefaultSearchPath.SRC_MAIN_RESOURCES.value() + fileName);
 					}
 		
 					// now load the properties


### PR DESCRIPTION
The existing code uses enum names instead of the values to try to load ESAPI.properties. 