### PR TITLE
Close #439 by racheting down default allowed file suffixes used with file uploads

### DIFF
--- a/configuration/esapi/ESAPI.properties
+++ b/configuration/esapi/ESAPI.properties
@@ -344,7 +344,7 @@ HttpUtilities.httpQueryParamNameLength=100
 #Maximum length for an http query parameter -- old default was 2000, but that's the max length for a URL...
 HttpUtilities.httpQueryParamValueLength=500
 # File upload configuration
-HttpUtilities.ApprovedUploadExtensions=.zip,.pdf,.doc,.docx,.ppt,.pptx,.tar,.gz,.tgz,.rar,.war,.jar,.ear,.xls,.rtf,.properties,.java,.class,.txt,.xml,.jsp,.jsf,.exe,.dll
+HttpUtilities.ApprovedUploadExtensions=.pdf,.doc,.docx,.ppt,.pptx,.xls,.xlsx,.rtf,.txt,.jpg,.png
 HttpUtilities.MaxUploadFileBytes=500000000
 # Using UTF-8 throughout your stack is highly recommended. That includes your database driver,
 # container, and any other technologies you may be using. Failure to do this may expose you

--- a/src/main/java/org/owasp/esapi/reference/DefaultSecurityConfiguration.java
+++ b/src/main/java/org/owasp/esapi/reference/DefaultSecurityConfiguration.java
@@ -407,7 +407,7 @@ public class DefaultSecurityConfiguration implements SecurityConfiguration {
 	 * {@inheritDoc}
 	 */
 	public List<String> getAllowedFileExtensions() {
-    	String def = ".zip,.pdf,.tar,.gz,.xls,.properties,.txt,.xml";
+        String def = ".pdf,.txt,.jpg,.png";
         String[] extList = getESAPIProperty(APPROVED_UPLOAD_EXTENSIONS,def).split(",");
         return Arrays.asList(extList);
     }

--- a/src/test/java/org/owasp/esapi/reference/ValidatorTest.java
+++ b/src/test/java/org/owasp/esapi/reference/ValidatorTest.java
@@ -228,7 +228,7 @@ public class ValidatorTest extends TestCase {
         System.out.println("getValidFileName");
         Validator instance = ESAPI.validator();
         ValidationErrorList errors = new ValidationErrorList();
-        String testName = "aspe%20ct.jar";
+        String testName = "aspe%20ct.txt";
         assertEquals("Percent encoding is not changed", testName, instance.getValidFileName("test", testName, ESAPI.securityConfiguration().getAllowedFileExtensions(), false, errors));
     }
 
@@ -307,7 +307,7 @@ public class ValidatorTest extends TestCase {
         char invalidChars[] = "/\\:*?\"<>|".toCharArray();
         for (int i = 0; i < invalidChars.length; i++) {
             assertFalse(invalidChars[i] + " is an invalid character for a filename",
-                    instance.isValidFileName("test", "as" + invalidChars[i] + "pect.jar", false));
+                    instance.isValidFileName("test", "as" + invalidChars[i] + "pect.txt", false));
         }
         assertFalse("Files must have an extension", instance.isValidFileName("test", "", false));
         assertFalse("Files must have a valid extension", instance.isValidFileName("test.invalidExtension", "", false));
@@ -523,21 +523,21 @@ public class ValidatorTest extends TestCase {
     public void testIsValidFileName() {
         System.out.println("isValidFileName");
         Validator instance = ESAPI.validator();
-        assertTrue("Simple valid filename with a valid extension", instance.isValidFileName("test", "aspect.jar", false));
-        assertTrue("All valid filename characters are accepted", instance.isValidFileName("test", "!@#$%^&{}[]()_+-=,.~'` abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.jar", false));
-        assertTrue("Legal filenames that decode to legal filenames are accepted", instance.isValidFileName("test", "aspe%20ct.jar", false));
+        assertTrue("Simple valid filename with a valid extension", instance.isValidFileName("test", "aspect.txt", false));
+        assertTrue("All valid filename characters are accepted", instance.isValidFileName("test", "!@#$%^&{}[]()_+-=,.~'` abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.txt", false));
+        assertTrue("Legal filenames that decode to legal filenames are accepted", instance.isValidFileName("test", "aspe%20ct.txt", false));
 
         ValidationErrorList errors = new ValidationErrorList();
-        assertTrue("Simple valid filename with a valid extension", instance.isValidFileName("test", "aspect.jar", false, errors));
-        assertTrue("All valid filename characters are accepted", instance.isValidFileName("test", "!@#$%^&{}[]()_+-=,.~'` abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.jar", false, errors));
-        assertTrue("Legal filenames that decode to legal filenames are accepted", instance.isValidFileName("test", "aspe%20ct.jar", false, errors));
+        assertTrue("Simple valid filename with a valid extension", instance.isValidFileName("test", "aspect.txt", false, errors));
+        assertTrue("All valid filename characters are accepted", instance.isValidFileName("test", "!@#$%^&{}[]()_+-=,.~'` abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.txt", false, errors));
+        assertTrue("Legal filenames that decode to legal filenames are accepted", instance.isValidFileName("test", "aspe%20ct.txt", false, errors));
         assertTrue(errors.size() == 0);
     }
 
     public void testIsValidFileUpload() throws IOException {
         System.out.println("isValidFileUpload");
         String filepath = new File(System.getProperty("user.dir")).getCanonicalPath();
-        String filename = "aspect.jar";
+        String filename = "aspect.txt";
         File parent = new File("/").getCanonicalFile();
         ValidationErrorList errors = new ValidationErrorList();
         byte[] content = null;
@@ -553,7 +553,7 @@ public class ValidatorTest extends TestCase {
         assertTrue(errors.size() == 0);
 
         filepath = "/ridiculous";
-        filename = "aspect.jar";
+        filename = "aspect.txt";
         try {
             content = "This is some file content".getBytes(PREFERRED_ENCODING);
         }

--- a/src/test/resources/esapi/ESAPI-CommaValidatorFileChecker.properties
+++ b/src/test/resources/esapi/ESAPI-CommaValidatorFileChecker.properties
@@ -334,7 +334,7 @@ HttpUtilities.ForceSecureCookies=true
 # Maximum size of HTTP headers
 HttpUtilities.MaxHeaderSize=4096
 # File upload configuration
-HttpUtilities.ApprovedUploadExtensions=.zip,.pdf,.doc,.docx,.ppt,.pptx,.tar,.gz,.tgz,.rar,.war,.jar,.ear,.xls,.rtf,.properties,.java,.class,.txt,.xml,.jsp,.jsf,.exe,.dll
+HttpUtilities.ApprovedUploadExtensions=.pdf,.doc,.docx,.ppt,.pptx,.xls,.xlsx,.rtf,.txt,.jpg,.png
 HttpUtilities.MaxUploadFileBytes=500000000
 # Using UTF-8 throughout your stack is highly recommended. That includes your database driver,
 # container, and any other technologies you may be using. Failure to do this may expose you

--- a/src/test/resources/esapi/ESAPI-DualValidatorFileChecker.properties
+++ b/src/test/resources/esapi/ESAPI-DualValidatorFileChecker.properties
@@ -334,7 +334,7 @@ HttpUtilities.ForceSecureCookies=true
 # Maximum size of HTTP headers
 HttpUtilities.MaxHeaderSize=4096
 # File upload configuration
-HttpUtilities.ApprovedUploadExtensions=.zip,.pdf,.doc,.docx,.ppt,.pptx,.tar,.gz,.tgz,.rar,.war,.jar,.ear,.xls,.rtf,.properties,.java,.class,.txt,.xml,.jsp,.jsf,.exe,.dll
+HttpUtilities.ApprovedUploadExtensions=.pdf,.doc,.docx,.ppt,.pptx,.xls,.xlsx,.rtf,.txt,.jpg,.png
 HttpUtilities.MaxUploadFileBytes=500000000
 # Using UTF-8 throughout your stack is highly recommended. That includes your database driver,
 # container, and any other technologies you may be using. Failure to do this may expose you

--- a/src/test/resources/esapi/ESAPI-QuotedValidatorFileChecker.properties
+++ b/src/test/resources/esapi/ESAPI-QuotedValidatorFileChecker.properties
@@ -334,7 +334,7 @@ HttpUtilities.ForceSecureCookies=true
 # Maximum size of HTTP headers
 HttpUtilities.MaxHeaderSize=4096
 # File upload configuration
-HttpUtilities.ApprovedUploadExtensions=.zip,.pdf,.doc,.docx,.ppt,.pptx,.tar,.gz,.tgz,.rar,.war,.jar,.ear,.xls,.rtf,.properties,.java,.class,.txt,.xml,.jsp,.jsf,.exe,.dll
+HttpUtilities.ApprovedUploadExtensions=.pdf,.doc,.docx,.ppt,.pptx,.xls,.xlsx,.rtf,.txt,.jpg,.png
 HttpUtilities.MaxUploadFileBytes=500000000
 # Using UTF-8 throughout your stack is highly recommended. That includes your database driver,
 # container, and any other technologies you may be using. Failure to do this may expose you

--- a/src/test/resources/esapi/ESAPI-SingleValidatorFileChecker.properties
+++ b/src/test/resources/esapi/ESAPI-SingleValidatorFileChecker.properties
@@ -334,7 +334,7 @@ HttpUtilities.ForceSecureCookies=true
 # Maximum size of HTTP headers
 HttpUtilities.MaxHeaderSize=4096
 # File upload configuration
-HttpUtilities.ApprovedUploadExtensions=.zip,.pdf,.doc,.docx,.ppt,.pptx,.tar,.gz,.tgz,.rar,.war,.jar,.ear,.xls,.rtf,.properties,.java,.class,.txt,.xml,.jsp,.jsf,.exe,.dll
+HttpUtilities.ApprovedUploadExtensions=.pdf,.doc,.docx,.ppt,.pptx,.xls,.xlsx,.rtf,.txt,.jpg,.png
 HttpUtilities.MaxUploadFileBytes=500000000
 # Using UTF-8 throughout your stack is highly recommended. That includes your database driver,
 # container, and any other technologies you may be using. Failure to do this may expose you

--- a/src/test/resources/esapi/ESAPI.properties
+++ b/src/test/resources/esapi/ESAPI.properties
@@ -356,7 +356,7 @@ HttpUtilities.httpQueryParamNameLength=100
 #Maximum length for an http query parameter -- old default was 2000, but that's the max length for a URL...
 HttpUtilities.httpQueryParamValueLength=500
 # File upload configuration
-HttpUtilities.ApprovedUploadExtensions=.zip,.pdf,.doc,.docx,.ppt,.pptx,.tar,.gz,.tgz,.rar,.war,.jar,.ear,.xls,.rtf,.properties,.java,.class,.txt,.xml,.jsp,.jsf,.exe,.dll
+HttpUtilities.ApprovedUploadExtensions=.pdf,.doc,.docx,.ppt,.pptx,.xls,.xlsx,.rtf,.txt,.jpg,.png
 HttpUtilities.MaxUploadFileBytes=500000000
 # Using UTF-8 throughout your stack is highly recommended. That includes your database driver,
 # container, and any other technologies you may be using. Failure to do this may expose you


### PR DESCRIPTION
Changed HttpUtilities.ApprovedUploadExtensions to proposed defaults as discussed in issue #439 and updated code and JUnit tests accordingly.