### PR TITLE
Close #438 by loosening JUnit test case assertion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.58</version>
+            <version>1.60</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
1. Updated BC from 1.58 to 1.60
2. Relax JUnit test assertion so that encoded key size is >= to requested key size instead of equal to requested key size.