### PR TITLE
ESAPIFilter in RI should allow login page destination to be configured #30

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.iws
 *.eml
 out/
+bin/
 
 # Leftover test files
 ciphertext-portable.ser

--- a/pom.xml
+++ b/pom.xml
@@ -340,7 +340,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.2</version>
+                <version>2.7</version>
                 <executions>
                     <execution>
                         <id>check-for-dependency-updates</id>

--- a/src/main/java/org/owasp/esapi/filters/ESAPIFilter.java
+++ b/src/main/java/org/owasp/esapi/filters/ESAPIFilter.java
@@ -41,6 +41,8 @@ public class ESAPIFilter implements Filter {
 
 	private static final String[] obfuscate = { "password" };
 
+	private String loginPage = "WEB-INF/login.jsp";
+
 	/**
 	 * Called by the web container to indicate to a filter that it is being
 	 * placed into service. The servlet container calls the init method exactly
@@ -54,6 +56,10 @@ public class ESAPIFilter implements Filter {
 		String path = filterConfig.getInitParameter("resourceDirectory");
 		if ( path != null ) {
 			ESAPI.securityConfiguration().setResourceDirectory( path );
+		}
+		String paramLoginPage = filterConfig.getInitParameter("loginPage");
+		if ( paramLoginPage != null ) {
+			loginPage = paramLoginPage;
 		}
 	}
 
@@ -85,7 +91,7 @@ public class ESAPIFilter implements Filter {
 			} catch( AuthenticationException e ) {
 				ESAPI.authenticator().logout();
 				request.setAttribute("message", "Authentication failed");
-				RequestDispatcher dispatcher = request.getRequestDispatcher("WEB-INF/login.jsp");
+				RequestDispatcher dispatcher = request.getRequestDispatcher(loginPage);
 				dispatcher.forward(request, response);
 				return;
 			}


### PR DESCRIPTION
I know I've messed up the pull request because of a previous pull request, just let me know what to do.

Regarding issue #30 I added "loginPage" filter init parameter in ESAPIFilter. I noticed though that there are other hardcoded pages such as WEB-INF/index.jsp on line 105, so you may want to create another issue for that (if there isn't one already, I haven't checked)

It's not perfect code because of the literal string "loginPage" in the middle of the code, but it should work fine.

I could not find any documentation to update to document this new "hidden feature" of ESAPIFilter. Unless this is a reference implementation (is that what RI means?) and not meant to be used in applications? Then why is it compiled in the library? I was unable to find (or create) appropriate unit tests either. In other words I wrote the code, mvn test keeps on giving me that known error, and I am unable to test if my code breaks anything or not.