### PR TITLE
Date validation rule 299

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,12 +129,6 @@
     </properties>
 
     <dependencies>
-        <!-- https://mvnrepository.com/artifact/joda-time/joda-time -->
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.10</version>
-        </dependency>
         <dependency>
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>

--- a/src/main/java/org/owasp/esapi/ValidationErrorList.java
+++ b/src/main/java/org/owasp/esapi/ValidationErrorList.java
@@ -91,8 +91,8 @@ public class ValidationErrorList {
 	 * @param vex	A {@code ValidationException}.
 	 */
 	public void addError(String context, ValidationException vex) {
-		if ( context == null ) throw new RuntimeException( "Context for cannot be null: " + vex.getLogMessage(), vex );
-		if ( vex == null ) throw new RuntimeException( "Context (" + context + ") cannot be null" );
+		if ( context == null ) throw new RuntimeException( "Context cannot be null: " + vex.getLogMessage(), vex );
+		if ( vex == null ) throw new RuntimeException( "ValidationException cannot be null for context  (" + context + ")" );
 		if (getError(context) != null) throw new RuntimeException("Context (" + context + ") already exists, must be unique");
 		errorList.put(context, vex);
 	}

--- a/src/main/java/org/owasp/esapi/reference/DefaultValidator.java
+++ b/src/main/java/org/owasp/esapi/reference/DefaultValidator.java
@@ -301,14 +301,14 @@ public class DefaultValidator implements org.owasp.esapi.Validator {
 	 */
 	public Date getValidDate(String context, String input, DateFormat format, boolean allowNull, ValidationErrorList errors) throws IntrusionException {
 	    Date safeDate = null;
-		    DateValidationRule dvr = new DateValidationRule( "SimpleDate", encoder, format);
-		    dvr.setAllowNull(allowNull);
-		    safeDate = dvr.sanitize(context, input, errors);
-	        if (!errors.isEmpty()) {
-	            safeDate = null;
-	        }
-		// error has been added to list, so return null
-		return safeDate;
+	    DateValidationRule dvr = new DateValidationRule( "SimpleDate", encoder, format);
+	    dvr.setAllowNull(allowNull);
+	    safeDate = dvr.sanitize(context, input, errors);
+	    if (!errors.isEmpty()) {
+	        safeDate = null;
+	    }
+	    // error has been added to list, so return null
+	    return safeDate;
 	}
 
 	/**

--- a/src/main/java/org/owasp/esapi/reference/DefaultValidator.java
+++ b/src/main/java/org/owasp/esapi/reference/DefaultValidator.java
@@ -291,8 +291,14 @@ public class DefaultValidator implements org.owasp.esapi.Validator {
 	 */
 	public Date getValidDate(String context, String input, DateFormat format, boolean allowNull) throws ValidationException, IntrusionException {
 		DateValidationRule dvr = new DateValidationRule( "SimpleDate", encoder, format);
+		ValidationErrorList vel = new ValidationErrorList();
 		dvr.setAllowNull(allowNull);
-		return dvr.getValid(context, input);
+		//return dvr.getValid(context, input);
+		Date validDate = dvr.sanitize(context, input, vel);
+		if (vel.isEmpty()) {
+		    return validDate;
+		}
+		throw vel.errors().get(0);
 	}
 
 	/**

--- a/src/main/java/org/owasp/esapi/reference/DefaultValidator.java
+++ b/src/main/java/org/owasp/esapi/reference/DefaultValidator.java
@@ -277,13 +277,8 @@ public class DefaultValidator implements org.owasp.esapi.Validator {
 	 * {@inheritDoc}
 	 */
 	public boolean isValidDate(String context, String input, DateFormat format, boolean allowNull, ValidationErrorList errors) throws IntrusionException {
-		try {
-			getValidDate( context, input, format, allowNull);
-			return true;
-		} catch( ValidationException e ) {
-            errors.addError(context, e);
-			return false;
-		}
+	    getValidDate( context, input, format, allowNull, errors);
+	    return errors.isEmpty();
 	}
 
 	/**

--- a/src/main/java/org/owasp/esapi/reference/DefaultValidator.java
+++ b/src/main/java/org/owasp/esapi/reference/DefaultValidator.java
@@ -290,14 +290,14 @@ public class DefaultValidator implements org.owasp.esapi.Validator {
 	 * {@inheritDoc}
 	 */
 	public Date getValidDate(String context, String input, DateFormat format, boolean allowNull) throws ValidationException, IntrusionException {
-		DateValidationRule dvr = new DateValidationRule( "SimpleDate", encoder, format);
+		
 		ValidationErrorList vel = new ValidationErrorList();
-		dvr.setAllowNull(allowNull);
-		//return dvr.getValid(context, input);
-		Date validDate = dvr.sanitize(context, input, vel);
+		Date validDate =  getValidDate(context, input, format, allowNull, vel);
+		
 		if (vel.isEmpty()) {
 		    return validDate;
 		}
+		
 		throw vel.errors().get(0);
 	}
 
@@ -305,13 +305,15 @@ public class DefaultValidator implements org.owasp.esapi.Validator {
 	 * {@inheritDoc}
 	 */
 	public Date getValidDate(String context, String input, DateFormat format, boolean allowNull, ValidationErrorList errors) throws IntrusionException {
-		try {
-			return getValidDate(context, input, format, allowNull);
-		} catch (ValidationException e) {
-			errors.addError(context, e);
-		}
+	    Date safeDate = null;
+		    DateValidationRule dvr = new DateValidationRule( "SimpleDate", encoder, format);
+		    dvr.setAllowNull(allowNull);
+		    safeDate = dvr.sanitize(context, input, errors);
+	        if (!errors.isEmpty()) {
+	            safeDate = null;
+	        }
 		// error has been added to list, so return null
-		return null;
+		return safeDate;
 	}
 
 	/**

--- a/src/main/java/org/owasp/esapi/reference/validation/DateValidationRule.java
+++ b/src/main/java/org/owasp/esapi/reference/validation/DateValidationRule.java
@@ -91,10 +91,14 @@ public class DateValidationRule extends BaseValidationRule {
 							+ input, context);
 		}
 
-	    String canonical = encoder.canonicalize(input);
-
-		try {
-			return format.parse(canonical);
+		 String canonical = encoder.canonicalize(input);
+	        try {
+	            Date rval = format.parse(canonical);
+	            String cycled = format.format(rval);
+	            if (!cycled.equals(canonical)) {
+	                throw new Exception("Parameter date is not a clean translation between String and Date contexts.  Check input for additional characters");
+	            }
+	            return rval;
 		} catch (Exception e) {
 			throw new ValidationException(context
 					+ ": Invalid date must follow the "

--- a/src/main/java/org/owasp/esapi/reference/validation/DateValidationRule.java
+++ b/src/main/java/org/owasp/esapi/reference/validation/DateValidationRule.java
@@ -60,7 +60,7 @@ public class DateValidationRule extends BaseValidationRule {
      * {@inheritDoc}
      */
 	public Date getValid( String context, String input ) throws ValidationException {
-		return safelyParse(context, input);
+		return safelyParse(context, input, false);
 	}
 
     /**
@@ -72,14 +72,14 @@ public class DateValidationRule extends BaseValidationRule {
 	public Date sanitize( String context, String input )  {
 		Date date = new Date(0);
 		try {
-			date = safelyParse(context, input);
+			date = safelyParse(context, input, true);
 		} catch (ValidationException e) {
 			// do nothing
 	    }
 		return date;
 	}
 	    
-	private Date safelyParse(String context, String input)
+	private Date safelyParse(String context, String input, boolean sanitize)
 			throws ValidationException {
 		// CHECKME should this allow empty Strings? "   " use IsBlank instead?
 		if (StringUtilities.isEmpty(input)) {
@@ -94,9 +94,11 @@ public class DateValidationRule extends BaseValidationRule {
 		 String canonical = encoder.canonicalize(input);
 	        try {
 	            Date rval = format.parse(canonical);
-	            String cycled = format.format(rval);
-	            if (!cycled.equals(canonical)) {
-	                throw new Exception("Parameter date is not a clean translation between String and Date contexts.  Check input for additional characters");
+	            if (sanitize) {
+	                String cycled = format.format(rval);
+	                if (!cycled.equals(canonical)) {
+	                    throw new Exception("Parameter date is not a clean translation between String and Date contexts.  Check input for additional characters");
+	                }
 	            }
 	            return rval;
 		} catch (Exception e) {

--- a/src/main/java/org/owasp/esapi/reference/validation/DateValidationRule.java
+++ b/src/main/java/org/owasp/esapi/reference/validation/DateValidationRule.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.Encoder;
 import org.owasp.esapi.StringUtilities;
+import org.owasp.esapi.ValidationErrorList;
 import org.owasp.esapi.errors.ValidationException;
 
 /**
@@ -70,14 +71,23 @@ public class DateValidationRule extends BaseValidationRule {
      */
 	@Override
 	public Date sanitize( String context, String input )  {
-		Date date = new Date(0);
-		try {
-			date = safelyParse(context, input, true);
-		} catch (ValidationException e) {
-			// do nothing
-	    }
-		return date;
+		return sanitize(context, input, null);
 	}
+	
+	/**
+     * {@inheritDoc}
+     */
+    public Date sanitize( String context, String input, ValidationErrorList errorList )  {
+        Date date = new Date(0);
+        try {
+            date = safelyParse(context, input, true);
+        } catch (ValidationException e) {
+            if (errorList != null) {
+                errorList.addError(context, e);
+            }
+        }
+        return date;
+    }
 	    
 	private Date safelyParse(String context, String input, boolean sanitize)
 			throws ValidationException {

--- a/src/test/java/org/owasp/esapi/ESAPIContractAPITest.java
+++ b/src/test/java/org/owasp/esapi/ESAPIContractAPITest.java
@@ -1,0 +1,52 @@
+package org.owasp.esapi;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.internal.verification.VerificationModeFactory;
+import org.owasp.esapi.util.ObjFactory;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ObjFactory.class})
+public class ESAPIContractAPITest {
+
+    @Mock
+    private SecurityConfiguration mockSecConfig;
+    
+    @Mock
+    private Validator mockValidator;
+    
+    @Before
+    public void configureStaticContexts() throws Exception {
+        PowerMockito.mockStatic(ObjFactory.class);
+        PowerMockito.when(ObjFactory.class, "make", ArgumentMatchers.anyString(), ArgumentMatchers.eq("SecurityConfiguration")).thenReturn(mockSecConfig);
+        PowerMockito.when(ObjFactory.class, "make", ArgumentMatchers.eq("MOCK_TEST_VALIDATOR"), ArgumentMatchers.eq("Validator")).thenReturn(mockValidator);
+        
+        PowerMockito.when(mockSecConfig.getValidationImplementation()).thenReturn("MOCK_TEST_VALIDATOR");
+    }
+    
+    @Test
+    public void testValidatorFromConfiguration() {
+        Validator validator = ESAPI.validator();
+        Assert.assertEquals("ESAPI Configuration should return Validator as specified by the SecurityConfiguration", mockValidator, validator);
+        
+        PowerMockito.verifyStatic(ObjFactory.class, VerificationModeFactory.times(1));
+        ObjFactory.make(ArgumentMatchers.anyString(), ArgumentMatchers.eq("SecurityConfiguration"));
+        
+        PowerMockito.verifyStatic(ObjFactory.class, VerificationModeFactory.times(1));
+        ObjFactory.make(ArgumentMatchers.eq("MOCK_TEST_VALIDATOR"), ArgumentMatchers.eq("Validator"));
+        
+        PowerMockito.verifyNoMoreInteractions(ObjFactory.class);
+        
+        Mockito.verify(mockSecConfig, Mockito.times(1)).getValidationImplementation();
+    }
+   
+}

--- a/src/test/java/org/owasp/esapi/ValidationErrorListTest.java
+++ b/src/test/java/org/owasp/esapi/ValidationErrorListTest.java
@@ -15,126 +15,76 @@
  */
 package org.owasp.esapi;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
-import org.owasp.esapi.errors.IntrusionException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TestName;
 import org.owasp.esapi.errors.ValidationException;
+
 
 /**
  * @author Jeff Williams (jeff.williams@aspectsecurity.com)
  */
-public class ValidationErrorListTest extends TestCase {
+public class ValidationErrorListTest {
+    @Rule
+    public ExpectedException exEx = ExpectedException.none();
+    @Rule
+    public TestName testName = new TestName();
 
-	/**
-	 * Instantiates a new executor test.
-	 * 
-	 * @param testName
-	 *            the test name
-	 */
-	public ValidationErrorListTest(String testName) {
-		super(testName);
-	}
+    ValidationErrorList vel = new ValidationErrorList();
+    ValidationException vex = new ValidationException(testName.getMethodName(), testName.getMethodName());
+    @Test
+    public void testAddErrorNullContextThrows() {
+        exEx.expect(RuntimeException.class);
+        exEx.expectMessage("Context cannot be null");
+        vel.addError(null, vex);
+    }
 
-	/**
-     * {@inheritDoc}
-     *
-     * @throws Exception
-     */
-	protected void setUp() throws Exception {
-		// none
-	}
+    @Test
+    public void testAddErrorNullExceptionThrows() {
+        exEx.expect(RuntimeException.class);
+        exEx.expectMessage("ValidationException cannot be null");
+        vel.addError(testName.getMethodName(), null);
+    }
+    public void testAddErrorDuplicateContextThrows() {
+        exEx.expect(RuntimeException.class);
+        exEx.expectMessage("already exists, must be unique");
+        vel.addError(testName.getMethodName(), vex);
+        vel.addError(testName.getMethodName(), vex);
+    }
 
-	/**
-     * {@inheritDoc}
-     *
-     * @throws Exception
-     */
-	protected void tearDown() throws Exception {
-		// none
-	}
+    @Test
+    public void testErrors() throws Exception {
+        vel.addError("context",  vex );
+        assertTrue("Validation Errors List should contain the added ValidationException Reference",vel.errors().contains( vex) );
+    }
 
-	/**
-	 * Suite.
-	 * 
-	 * @return the test
-	 */
-	public static Test suite() {
-		TestSuite suite = new TestSuite(ValidationErrorListTest.class);
-		return suite;
-	}
-	
-	public void testAddError() throws Exception {
-		System.out.println("testAddError");
-		ValidationErrorList vel = new ValidationErrorList();
-		ValidationException vex = createValidationException();
-		vel.addError("context", vex );
-		try {
-			vel.addError(null, vex );
-			fail();
-		} catch( Exception e ) {
-			// expected
-		}
-		try {
-			vel.addError("context1", null );
-			fail();
-		} catch( Exception e ) {
-			// expected
-		}
-		try {
-			vel.addError("context", vex );  // add the same context again
-			fail();
-		} catch( Exception e ) {
-			// expected
-		}
-	}
+    @Test
+    public void testGetError() throws Exception {
+        vel.addError("context",  vex );
+        assertTrue( vel.getError( "context" ) == vex );
+        assertNull( vel.getError( "ridiculous" ) );
+    }
 
-	public void testErrors() throws Exception {
-		System.out.println("testErrors");
-		ValidationErrorList vel = new ValidationErrorList();
-		ValidationException vex = createValidationException();
-		vel.addError("context",  vex );
-		assertTrue( vel.errors().get(0) == vex );
-	}
+    @Test
+    public void testIsEmpty() throws Exception {
+        assertTrue( vel.isEmpty() );
+        vel.addError("context",  vex );
+        assertFalse( vel.isEmpty() );
+    }
 
-	public void testGetError() throws Exception {
-		System.out.println("testGetError");
-		ValidationErrorList vel = new ValidationErrorList();
-		ValidationException vex = createValidationException();
-		vel.addError("context",  vex );
-		assertTrue( vel.getError( "context" ) == vex );
-		assertTrue( vel.getError( "ridiculous" ) == null );
-	}
+    @Test
+    public void testSize() throws Exception {
+        assertEquals(0, vel.size() );
+        vel.addError("context",  vex );
+        assertEquals(1, vel.size());
+    }
 
-	public void testIsEmpty() throws Exception {
-		System.out.println("testIsEmpty");
-		ValidationErrorList vel = new ValidationErrorList();
-		assertTrue( vel.isEmpty() );
-		ValidationException vex = createValidationException();
-		vel.addError("context",  vex );
-		assertFalse( vel.isEmpty() );
-	}
-
-	public void testSize() throws Exception {
-		System.out.println("testSize");
-		ValidationErrorList vel = new ValidationErrorList();
-		assertTrue( vel.size() == 0 );
-		ValidationException vex = createValidationException();
-		vel.addError("context",  vex );
-		assertTrue( vel.size() == 1 );
-	}
-
-	private ValidationException createValidationException() {
-		ValidationException vex = null;
-		try {
-			vex = new ValidationException("User message", "Log Message");
-		} catch( IntrusionException e ) {
-			// expected occasionally
-		}
-		return vex;
-	}
-	
 }
 
 

--- a/src/test/java/org/owasp/esapi/reference/DefaultValidaterDateAPITest.java
+++ b/src/test/java/org/owasp/esapi/reference/DefaultValidaterDateAPITest.java
@@ -11,9 +11,14 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.owasp.esapi.Encoder;
 import org.owasp.esapi.reference.validation.DateValidationRule;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * This class contains a subsection of tests of the DefaultValidator class 
@@ -21,6 +26,8 @@ import org.owasp.esapi.reference.validation.DateValidationRule;
  * 
  */
 @Ignore
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(DefaultValidator.class)
 public class DefaultValidaterDateAPITest {
     @Rule
     public ExpectedException exEx = ExpectedException.none();
@@ -37,7 +44,7 @@ public class DefaultValidaterDateAPITest {
     
     
     @Before
-    public void setup() {
+    public void setup() throws Exception {
         contextStr = testName.getMethodName();        
         
         mockEncoder = Mockito.mock(Encoder.class);
@@ -45,11 +52,18 @@ public class DefaultValidaterDateAPITest {
         
         spyDateRule = new DateValidationRule(contextStr, mockEncoder, testFormat);
         spyDateRule = Mockito.spy(spyDateRule);
-        
         //FIXME:  Argument Matchers for all to allow any ValidationErrorList
-        Mockito.doReturn(testDate).when(spyDateRule).sanitize(contextStr, dateString, null);
+      /*  Is.is(contextStr).
         
-        //FIXME:  when DateValidationRule ctr is called, return spyDateRule!
+        ArgumentMatcher<Object> contextMatch = new Equals(contextStr);
+        ArgumentMatcher<Object> dateInputMatch = new Equals(dateString);
+        ArgumentMatcher<Object> errorListTypeMatch = new InstanceOf(ValidationErrorList.class);
+        Mockito.doReturn(testDate).when(spyDateRule).sanitize(Is.is(contextStr), Is.is(dateString), Is.isA(ValidationErrorList.class));
+        Mockito.when(spyDateRule).s*/
+        
+        
+        //PowerMockito.whenNew(DateValidationRule.class).withArguments(ArgumentMatchers.anyString(), ArgumentMatchers.eq(dateString), ArgumentMatchers.eq(testFormat)).thenReturn(spyDateRule);
+        PowerMockito.whenNew(DateValidationRule.class).withArguments(ArgumentMatchers.anyString(), ArgumentMatchers.any(Encoder.class), ArgumentMatchers.any(DateFormat.class)).thenReturn(spyDateRule);
     }
     
     @Test

--- a/src/test/java/org/owasp/esapi/reference/DefaultValidaterDateAPITest.java
+++ b/src/test/java/org/owasp/esapi/reference/DefaultValidaterDateAPITest.java
@@ -2,17 +2,21 @@ package org.owasp.esapi.reference;
 
 
 import java.text.DateFormat;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.Locale;
 
+import org.hamcrest.core.Is;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.owasp.esapi.Encoder;
@@ -38,6 +42,7 @@ public class DefaultValidaterDateAPITest {
     public TestName testName = new TestName();
     private String dateString="Input Does not matter in this context";
     
+    private ValidationException validationEx;
     private Date testDate = new Date();
     private String contextStr;
     private Encoder mockEncoder;
@@ -50,21 +55,24 @@ public class DefaultValidaterDateAPITest {
     
     @Before
     public void setup() throws Exception {
-        contextStr = testName.getMethodName();        
+        contextStr = testName.getMethodName();
+        
+        validationEx = new ValidationException(contextStr, contextStr);
         
         mockEncoder = Mockito.mock(Encoder.class);
         uit = new DefaultValidator(mockEncoder);
         
         spyDateRule = new DateValidationRule(contextStr, mockEncoder, testFormat);
         spyDateRule = Mockito.spy(spyDateRule);
-        
-        
         PowerMockito.whenNew(DateValidationRule.class).withArguments(ArgumentMatchers.anyString(), ArgumentMatchers.eq(mockEncoder), ArgumentMatchers.eq(testFormat)).thenReturn(spyDateRule);
+        
+        errors = Mockito.spy(errors);
+        PowerMockito.whenNew(ValidationErrorList.class).withNoArguments().thenReturn(errors);
     }
     
     @After
     public void tearDown() {
-        Mockito.verifyNoMoreInteractions(spyDateRule);
+        Mockito.verifyNoMoreInteractions(spyDateRule, errors);
     }
     
     @Test
@@ -74,6 +82,8 @@ public class DefaultValidaterDateAPITest {
         boolean isValid = uit.isValidDate(contextStr, dateString, testFormat, true);
         Assert.assertTrue("Mock is configured to return a valid date, return should be equally valid.", isValid);
         
+        Mockito.verify(errors, Mockito.atLeastOnce()).isEmpty();
+        Mockito.verify(errors, Mockito.times(0)).errors();
         Mockito.verify(spyDateRule, Mockito.times(1)).setAllowNull(true);
         Mockito.verify(spyDateRule, Mockito.times(1)).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
     }
@@ -85,6 +95,8 @@ public class DefaultValidaterDateAPITest {
         boolean isValid = uit.isValidDate(contextStr, dateString, testFormat, true, errors);
         Assert.assertTrue("Mock is configured to return a valid date, return should be equally valid.", isValid);
         
+        Mockito.verify(errors, Mockito.atLeastOnce()).isEmpty();
+        Mockito.verify(errors, Mockito.times(0)).errors();
         Mockito.verify(spyDateRule, Mockito.times(1)).setAllowNull(true);
         Mockito.verify(spyDateRule, Mockito.times(1)).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.eq(errors));
     }
@@ -95,6 +107,8 @@ public class DefaultValidaterDateAPITest {
         Date validDate = uit.getValidDate(contextStr, dateString, testFormat, true);
         Assert.assertEquals("ValidDate should match the mock's configured return value", testDate, validDate);
         
+        Mockito.verify(errors, Mockito.atLeastOnce()).isEmpty();
+        Mockito.verify(errors, Mockito.times(0)).errors();
         Mockito.verify(spyDateRule, Mockito.times(1)).setAllowNull(true);
         Mockito.verify(spyDateRule, Mockito.times(1)).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
     }
@@ -104,7 +118,74 @@ public class DefaultValidaterDateAPITest {
         Mockito.doReturn(testDate).when(spyDateRule).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
         Date validDate = uit.getValidDate(contextStr, dateString, testFormat, true, errors);
         Assert.assertEquals("ValidDate should match the mock's configured return value", testDate, validDate);
+        
+        Mockito.verify(errors, Mockito.atLeastOnce()).isEmpty();
+        Mockito.verify(errors, Mockito.times(0)).errors();
         Mockito.verify(spyDateRule, Mockito.times(1)).setAllowNull(true);
         Mockito.verify(spyDateRule, Mockito.times(1)).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.eq(errors));
     }
+    
+    
+    @Test
+    public void testIsValidDateOnValidationError() {
+        Mockito.doReturn(false).when(errors).isEmpty();
+        Mockito.doReturn(Arrays.asList(validationEx)).when(errors).errors();
+        
+        Mockito.doReturn(testDate).when(spyDateRule).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+        
+        boolean isValid = uit.isValidDate(contextStr, dateString, testFormat, true);
+        Assert.assertFalse("On ValidationException input should be invalid", isValid);
+        
+        Mockito.verify(errors, Mockito.atLeastOnce()).isEmpty();
+        Mockito.verify(errors, Mockito.times(1)).errors();
+        Mockito.verify(spyDateRule, Mockito.times(1)).setAllowNull(true);
+        Mockito.verify(spyDateRule, Mockito.times(1)).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+    }
+    
+    @Test
+    public void testIsValidDateErrorListOnValidationError() {
+        Mockito.doReturn(false).when(errors).isEmpty();
+        Mockito.doReturn(Arrays.asList(validationEx)).when(errors).errors();
+        
+        Mockito.doReturn(testDate).when(spyDateRule).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+        
+        boolean isValid = uit.isValidDate(contextStr, dateString, testFormat, true, errors);
+        Assert.assertFalse("On ValidationException input should be invalid", isValid);
+        
+        Mockito.verify(errors, Mockito.times(2)).isEmpty();
+        Mockito.verify(errors, Mockito.times(0)).errors();
+        Mockito.verify(spyDateRule, Mockito.times(1)).setAllowNull(true);
+        Mockito.verify(spyDateRule, Mockito.times(1)).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.eq(errors));
+    }
+    @Test
+    public void testGetValidDateOnValidationError() throws IntrusionException, ValidationException {
+        exEx.expect(Is.is(validationEx));
+        Mockito.doReturn(false).when(errors).isEmpty();
+        Mockito.doReturn(Arrays.asList(validationEx)).when(errors).errors();
+
+        Mockito.doReturn(testDate).when(spyDateRule).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+        try {
+            uit.getValidDate(contextStr, dateString, testFormat, true);
+        } finally {
+            Mockito.verify(errors, Mockito.atLeastOnce()).isEmpty();
+            Mockito.verify(errors, Mockito.times(1)).errors();
+            Mockito.verify(spyDateRule, Mockito.times(1)).setAllowNull(true);
+            Mockito.verify(spyDateRule, Mockito.times(1)).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+        }
+    }
+    
+    @Test
+    public void testGetValidDateErrorListOnValidationError() {
+        Mockito.doReturn(false).when(errors).isEmpty();
+        Mockito.doReturn(Arrays.asList(validationEx)).when(errors).errors();
+
+        Mockito.doReturn(testDate).when(spyDateRule).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+        Date validDate = uit.getValidDate(contextStr, dateString, testFormat, true, errors);
+        Assert.assertNull(validDate);
+        Mockito.verify(errors, Mockito.atLeastOnce()).isEmpty();
+        Mockito.verify(errors, Mockito.times(0)).errors();
+        Mockito.verify(spyDateRule, Mockito.times(1)).setAllowNull(true);
+        Mockito.verify(spyDateRule, Mockito.times(1)).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+    }
+
 }

--- a/src/test/java/org/owasp/esapi/reference/DefaultValidaterDateAPITest.java
+++ b/src/test/java/org/owasp/esapi/reference/DefaultValidaterDateAPITest.java
@@ -1,6 +1,18 @@
 package org.owasp.esapi.reference;
 
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
 import java.text.DateFormat;
 import java.util.Arrays;
 import java.util.Date;
@@ -10,21 +22,16 @@ import org.hamcrest.core.Is;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
 import org.owasp.esapi.Encoder;
 import org.owasp.esapi.ValidationErrorList;
 import org.owasp.esapi.errors.IntrusionException;
 import org.owasp.esapi.errors.ValidationException;
 import org.owasp.esapi.reference.validation.DateValidationRule;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -59,133 +66,133 @@ public class DefaultValidaterDateAPITest {
         
         validationEx = new ValidationException(contextStr, contextStr);
         
-        mockEncoder = Mockito.mock(Encoder.class);
+        mockEncoder = mock(Encoder.class);
         uit = new DefaultValidator(mockEncoder);
         
         spyDateRule = new DateValidationRule(contextStr, mockEncoder, testFormat);
-        spyDateRule = Mockito.spy(spyDateRule);
-        PowerMockito.whenNew(DateValidationRule.class).withArguments(ArgumentMatchers.anyString(), ArgumentMatchers.eq(mockEncoder), ArgumentMatchers.eq(testFormat)).thenReturn(spyDateRule);
+        spyDateRule = spy(spyDateRule);
+        whenNew(DateValidationRule.class).withArguments(anyString(), eq(mockEncoder), eq(testFormat)).thenReturn(spyDateRule);
         
-        errors = Mockito.spy(errors);
-        PowerMockito.whenNew(ValidationErrorList.class).withNoArguments().thenReturn(errors);
+        errors = spy(errors);
+        whenNew(ValidationErrorList.class).withNoArguments().thenReturn(errors);
     }
     
     @After
     public void tearDown() {
-        Mockito.verifyNoMoreInteractions(spyDateRule, errors);
+        verifyNoMoreInteractions(spyDateRule, errors);
     }
     
     @Test
     public void testIsValidDate() {
-        Mockito.doReturn(testDate).when(spyDateRule).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+        doReturn(testDate).when(spyDateRule).sanitize(eq(contextStr), eq(dateString), isA(ValidationErrorList.class));
         
         boolean isValid = uit.isValidDate(contextStr, dateString, testFormat, true);
         Assert.assertTrue("Mock is configured to return a valid date, return should be equally valid.", isValid);
         
-        Mockito.verify(errors, Mockito.atLeastOnce()).isEmpty();
-        Mockito.verify(errors, Mockito.times(0)).errors();
-        Mockito.verify(spyDateRule, Mockito.times(1)).setAllowNull(true);
-        Mockito.verify(spyDateRule, Mockito.times(1)).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+        verify(errors, atLeastOnce()).isEmpty();
+        verify(errors, times(0)).errors();
+        verify(spyDateRule, times(1)).setAllowNull(true);
+        verify(spyDateRule, times(1)).sanitize(eq(contextStr), eq(dateString), isA(ValidationErrorList.class));
     }
     
     @Test
     public void testIsValidDateErrorList() {
-        Mockito.doReturn(testDate).when(spyDateRule).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+        doReturn(testDate).when(spyDateRule).sanitize(eq(contextStr), eq(dateString), isA(ValidationErrorList.class));
         
         boolean isValid = uit.isValidDate(contextStr, dateString, testFormat, true, errors);
         Assert.assertTrue("Mock is configured to return a valid date, return should be equally valid.", isValid);
         
-        Mockito.verify(errors, Mockito.atLeastOnce()).isEmpty();
-        Mockito.verify(errors, Mockito.times(0)).errors();
-        Mockito.verify(spyDateRule, Mockito.times(1)).setAllowNull(true);
-        Mockito.verify(spyDateRule, Mockito.times(1)).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.eq(errors));
+        verify(errors, atLeastOnce()).isEmpty();
+        verify(errors, times(0)).errors();
+        verify(spyDateRule, times(1)).setAllowNull(true);
+        verify(spyDateRule, times(1)).sanitize(eq(contextStr), eq(dateString), eq(errors));
     }
     
     @Test
     public void testGetValidDate() throws IntrusionException, ValidationException {
-        Mockito.doReturn(testDate).when(spyDateRule).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+        doReturn(testDate).when(spyDateRule).sanitize(eq(contextStr), eq(dateString), isA(ValidationErrorList.class));
         Date validDate = uit.getValidDate(contextStr, dateString, testFormat, true);
         Assert.assertEquals("ValidDate should match the mock's configured return value", testDate, validDate);
         
-        Mockito.verify(errors, Mockito.atLeastOnce()).isEmpty();
-        Mockito.verify(errors, Mockito.times(0)).errors();
-        Mockito.verify(spyDateRule, Mockito.times(1)).setAllowNull(true);
-        Mockito.verify(spyDateRule, Mockito.times(1)).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+        verify(errors, atLeastOnce()).isEmpty();
+        verify(errors, times(0)).errors();
+        verify(spyDateRule, times(1)).setAllowNull(true);
+        verify(spyDateRule, times(1)).sanitize(eq(contextStr), eq(dateString), isA(ValidationErrorList.class));
     }
     
     @Test
     public void testGetValidDateErrorList() {
-        Mockito.doReturn(testDate).when(spyDateRule).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+        doReturn(testDate).when(spyDateRule).sanitize(eq(contextStr), eq(dateString), isA(ValidationErrorList.class));
         Date validDate = uit.getValidDate(contextStr, dateString, testFormat, true, errors);
         Assert.assertEquals("ValidDate should match the mock's configured return value", testDate, validDate);
         
-        Mockito.verify(errors, Mockito.atLeastOnce()).isEmpty();
-        Mockito.verify(errors, Mockito.times(0)).errors();
-        Mockito.verify(spyDateRule, Mockito.times(1)).setAllowNull(true);
-        Mockito.verify(spyDateRule, Mockito.times(1)).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.eq(errors));
+        verify(errors, atLeastOnce()).isEmpty();
+        verify(errors, times(0)).errors();
+        verify(spyDateRule, times(1)).setAllowNull(true);
+        verify(spyDateRule, times(1)).sanitize(eq(contextStr), eq(dateString), eq(errors));
     }
     
     
     @Test
     public void testIsValidDateOnValidationError() {
-        Mockito.doReturn(false).when(errors).isEmpty();
-        Mockito.doReturn(Arrays.asList(validationEx)).when(errors).errors();
+        doReturn(false).when(errors).isEmpty();
+        doReturn(Arrays.asList(validationEx)).when(errors).errors();
         
-        Mockito.doReturn(testDate).when(spyDateRule).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+        doReturn(testDate).when(spyDateRule).sanitize(eq(contextStr), eq(dateString), isA(ValidationErrorList.class));
         
         boolean isValid = uit.isValidDate(contextStr, dateString, testFormat, true);
         Assert.assertFalse("On ValidationException input should be invalid", isValid);
         
-        Mockito.verify(errors, Mockito.atLeastOnce()).isEmpty();
-        Mockito.verify(errors, Mockito.times(1)).errors();
-        Mockito.verify(spyDateRule, Mockito.times(1)).setAllowNull(true);
-        Mockito.verify(spyDateRule, Mockito.times(1)).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+        verify(errors, atLeastOnce()).isEmpty();
+        verify(errors, times(1)).errors();
+        verify(spyDateRule, times(1)).setAllowNull(true);
+        verify(spyDateRule, times(1)).sanitize(eq(contextStr), eq(dateString), isA(ValidationErrorList.class));
     }
     
     @Test
     public void testIsValidDateErrorListOnValidationError() {
-        Mockito.doReturn(false).when(errors).isEmpty();
-        Mockito.doReturn(Arrays.asList(validationEx)).when(errors).errors();
+        doReturn(false).when(errors).isEmpty();
+        doReturn(Arrays.asList(validationEx)).when(errors).errors();
         
-        Mockito.doReturn(testDate).when(spyDateRule).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+        doReturn(testDate).when(spyDateRule).sanitize(eq(contextStr), eq(dateString), isA(ValidationErrorList.class));
         
         boolean isValid = uit.isValidDate(contextStr, dateString, testFormat, true, errors);
         Assert.assertFalse("On ValidationException input should be invalid", isValid);
         
-        Mockito.verify(errors, Mockito.times(2)).isEmpty();
-        Mockito.verify(errors, Mockito.times(0)).errors();
-        Mockito.verify(spyDateRule, Mockito.times(1)).setAllowNull(true);
-        Mockito.verify(spyDateRule, Mockito.times(1)).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.eq(errors));
+        verify(errors, times(2)).isEmpty();
+        verify(errors, times(0)).errors();
+        verify(spyDateRule, times(1)).setAllowNull(true);
+        verify(spyDateRule, times(1)).sanitize(eq(contextStr), eq(dateString), eq(errors));
     }
     @Test
     public void testGetValidDateOnValidationError() throws IntrusionException, ValidationException {
         exEx.expect(Is.is(validationEx));
-        Mockito.doReturn(false).when(errors).isEmpty();
-        Mockito.doReturn(Arrays.asList(validationEx)).when(errors).errors();
+        doReturn(false).when(errors).isEmpty();
+        doReturn(Arrays.asList(validationEx)).when(errors).errors();
 
-        Mockito.doReturn(testDate).when(spyDateRule).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+        doReturn(testDate).when(spyDateRule).sanitize(eq(contextStr), eq(dateString), isA(ValidationErrorList.class));
         try {
             uit.getValidDate(contextStr, dateString, testFormat, true);
         } finally {
-            Mockito.verify(errors, Mockito.atLeastOnce()).isEmpty();
-            Mockito.verify(errors, Mockito.times(1)).errors();
-            Mockito.verify(spyDateRule, Mockito.times(1)).setAllowNull(true);
-            Mockito.verify(spyDateRule, Mockito.times(1)).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+            verify(errors, atLeastOnce()).isEmpty();
+            verify(errors, times(1)).errors();
+            verify(spyDateRule, times(1)).setAllowNull(true);
+            verify(spyDateRule, times(1)).sanitize(eq(contextStr), eq(dateString), isA(ValidationErrorList.class));
         }
     }
     
     @Test
     public void testGetValidDateErrorListOnValidationError() {
-        Mockito.doReturn(false).when(errors).isEmpty();
-        Mockito.doReturn(Arrays.asList(validationEx)).when(errors).errors();
+        doReturn(false).when(errors).isEmpty();
+        doReturn(Arrays.asList(validationEx)).when(errors).errors();
 
-        Mockito.doReturn(testDate).when(spyDateRule).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+        doReturn(testDate).when(spyDateRule).sanitize(eq(contextStr), eq(dateString), isA(ValidationErrorList.class));
         Date validDate = uit.getValidDate(contextStr, dateString, testFormat, true, errors);
         Assert.assertNull(validDate);
-        Mockito.verify(errors, Mockito.atLeastOnce()).isEmpty();
-        Mockito.verify(errors, Mockito.times(0)).errors();
-        Mockito.verify(spyDateRule, Mockito.times(1)).setAllowNull(true);
-        Mockito.verify(spyDateRule, Mockito.times(1)).sanitize(ArgumentMatchers.eq(contextStr), ArgumentMatchers.eq(dateString), ArgumentMatchers.isA(ValidationErrorList.class));
+        verify(errors, atLeastOnce()).isEmpty();
+        verify(errors, times(0)).errors();
+        verify(spyDateRule, times(1)).setAllowNull(true);
+        verify(spyDateRule, times(1)).sanitize(eq(contextStr), eq(dateString), isA(ValidationErrorList.class));
     }
 
 }

--- a/src/test/java/org/owasp/esapi/reference/DefaultValidaterDateAPITest.java
+++ b/src/test/java/org/owasp/esapi/reference/DefaultValidaterDateAPITest.java
@@ -1,0 +1,77 @@
+package org.owasp.esapi.reference;
+
+
+import java.text.DateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TestName;
+import org.mockito.Mockito;
+import org.owasp.esapi.Encoder;
+import org.owasp.esapi.reference.validation.DateValidationRule;
+
+/**
+ * This class contains a subsection of tests of the DefaultValidator class 
+ * SPECIFIC TO THE DATE VALIDATION API.
+ * 
+ */
+@Ignore
+public class DefaultValidaterDateAPITest {
+    @Rule
+    public ExpectedException exEx = ExpectedException.none();
+    @Rule
+    public TestName testName = new TestName();
+    private String dateString="Input Does not matter in this context";
+    
+    private Date testDate = new Date();
+    private String contextStr;
+    private Encoder mockEncoder;
+    private DateFormat testFormat = DateFormat.getDateInstance(DateFormat.MEDIUM, Locale.US);
+    private DateValidationRule spyDateRule;
+    private DefaultValidator uit;
+    
+    
+    @Before
+    public void setup() {
+        contextStr = testName.getMethodName();        
+        
+        mockEncoder = Mockito.mock(Encoder.class);
+        uit = new DefaultValidator(mockEncoder);
+        
+        spyDateRule = new DateValidationRule(contextStr, mockEncoder, testFormat);
+        spyDateRule = Mockito.spy(spyDateRule);
+        
+        //FIXME:  Argument Matchers for all to allow any ValidationErrorList
+        Mockito.doReturn(testDate).when(spyDateRule).sanitize(contextStr, dateString, null);
+        
+        //FIXME:  when DateValidationRule ctr is called, return spyDateRule!
+    }
+    
+    @Test
+    public void testIsValidDate() {
+        uit.isValidDate(contextStr, dateString, testFormat, true);
+        
+        Mockito.verify(spyDateRule, Mockito.times(1)).setAllowNull(true);
+        Mockito.verify(spyDateRule, Mockito.times(1)).sanitize(contextStr, dateString, null);
+    }
+    
+    @Test
+    public void testIsValidDateErrorList() {
+    
+    }
+    
+    @Test
+    public void testGetValidDate() {
+    
+    }
+    
+    @Test
+    public void testGetValidDateErrorList() {
+    
+    }
+}

--- a/src/test/java/org/owasp/esapi/reference/ValidatorTest.java
+++ b/src/test/java/org/owasp/esapi/reference/ValidatorTest.java
@@ -336,19 +336,19 @@ public class ValidatorTest extends TestCase {
         Validator instance = ESAPI.validator();
         DateFormat df=new SimpleDateFormat("dd/MM/yyyy");      
         df.setLenient(true);
-        System.out.println("Result:" + instance.isValidDate("Pruebas-", "01/01/2aaa", df, false));
+        assertFalse(instance.isValidDate("Pruebas-", "01/01/2aaa", df, false));
         df=new SimpleDateFormat("yyyy/dd/MM");      
         df.setLenient(true);
-        System.out.println("Result:"  + instance.isValidDate("Pruebas-", "2aaa/01/01", df, false));
+        assertFalse(instance.isValidDate("Pruebas-", "2aaa/01/01", df, false));
         df=new SimpleDateFormat("dd/yyyy/MM");      
         df.setLenient(true);
-        System.out.println("Result:"  + instance.isValidDate("Pruebas-", "01/2012'SELECT * FROM user_table'/01", df, false));
+        assertFalse(instance.isValidDate("Pruebas-", "01/2012'SELECT * FROM user_table'/01", df, false));
         df=new SimpleDateFormat("dd/MM/yyyy");      
         df.setLenient(true);
-        System.out.println("Result:"  + instance.isValidDate("Pruebas-", "01/01/2012'SELECT * FROM user_table'", df, false));
+        assertFalse(instance.isValidDate("Pruebas-", "01/01/2012'SELECT * FROM user_table'", df, false));
         df=new SimpleDateFormat("dd/yyyy/MM");      
         df.setLenient(true);
-        System.out.println("Result:"  + instance.isValidDate("Pruebas-", "01/2aaa/01", df, false));
+        assertFalse(instance.isValidDate("Pruebas-", "01/2aaa/01", df, false));
     }
 
     public void testIsValidDirectoryPath() throws IOException {

--- a/src/test/java/org/owasp/esapi/reference/ValidatorTest.java
+++ b/src/test/java/org/owasp/esapi/reference/ValidatorTest.java
@@ -349,6 +349,8 @@ public class ValidatorTest extends TestCase {
         df=new SimpleDateFormat("dd/yyyy/MM");      
         df.setLenient(true);
         assertFalse(instance.isValidDate("Pruebas-", "01/2aaa/01", df, false));
+        df = SimpleDateFormat.getDateInstance(SimpleDateFormat.LONG, Locale.US);
+        assertFalse(instance.isValidDate("datetest4", "September 11, 2001' union select * from another_table where user_id like '%", df, false));
     }
 
     public void testIsValidDirectoryPath() throws IOException {

--- a/src/test/java/org/owasp/esapi/reference/ValidatorTest.java
+++ b/src/test/java/org/owasp/esapi/reference/ValidatorTest.java
@@ -331,6 +331,25 @@ public class ValidatorTest extends TestCase {
         assertTrue(errors.size()==2);
 
     }
+    
+    public void testIsValidDateIssue299() {
+        Validator instance = ESAPI.validator();
+        DateFormat df=new SimpleDateFormat("dd/MM/yyyy");      
+        df.setLenient(true);
+        System.out.println("Result:" + instance.isValidDate("Pruebas-", "01/01/2aaa", df, false));
+        df=new SimpleDateFormat("yyyy/dd/MM");      
+        df.setLenient(true);
+        System.out.println("Result:"  + instance.isValidDate("Pruebas-", "2aaa/01/01", df, false));
+        df=new SimpleDateFormat("dd/yyyy/MM");      
+        df.setLenient(true);
+        System.out.println("Result:"  + instance.isValidDate("Pruebas-", "01/2012'SELECT * FROM user_table'/01", df, false));
+        df=new SimpleDateFormat("dd/MM/yyyy");      
+        df.setLenient(true);
+        System.out.println("Result:"  + instance.isValidDate("Pruebas-", "01/01/2012'SELECT * FROM user_table'", df, false));
+        df=new SimpleDateFormat("dd/yyyy/MM");      
+        df.setLenient(true);
+        System.out.println("Result:"  + instance.isValidDate("Pruebas-", "01/2aaa/01", df, false));
+    }
 
     public void testIsValidDirectoryPath() throws IOException {
         System.out.println("isValidDirectoryPath");

--- a/src/test/java/org/owasp/esapi/reference/ValidatorTest.java
+++ b/src/test/java/org/owasp/esapi/reference/ValidatorTest.java
@@ -135,7 +135,7 @@ public class ValidatorTest extends TestCase {
     	System.out.println("getValidDate");
     	Validator instance = ESAPI.validator();
     	ValidationErrorList errors = new ValidationErrorList();
-    	assertTrue(instance.getValidDate("datetest1", "June 23, 1967", DateFormat.getDateInstance(DateFormat.MEDIUM, Locale.US), false) != null);
+    	assertTrue(instance.getValidDate("datetest1", "June 23, 1967", DateFormat.getDateInstance(DateFormat.LONG, Locale.US), false) != null);
     	instance.getValidDate("datetest2", "freakshow", DateFormat.getDateInstance(), false, errors);
     	assertEquals(1, errors.size());
 
@@ -317,7 +317,7 @@ public class ValidatorTest extends TestCase {
     public void testIsValidDate() {
         System.out.println("isValidDate");
         Validator instance = ESAPI.validator();
-        DateFormat format = SimpleDateFormat.getDateInstance(SimpleDateFormat.MEDIUM, Locale.US);
+        DateFormat format = SimpleDateFormat.getDateInstance(SimpleDateFormat.LONG, Locale.US);
         assertTrue(instance.isValidDate("datetest1", "September 11, 2001", format, true));
         assertFalse(instance.isValidDate("datetest2", null, format, false));
         assertFalse(instance.isValidDate("datetest3", "", format, false));

--- a/src/test/java/org/owasp/esapi/reference/ValidatorTest.java
+++ b/src/test/java/org/owasp/esapi/reference/ValidatorTest.java
@@ -15,10 +15,27 @@
  */
 package org.owasp.esapi.reference;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import org.owasp.esapi.*;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.servlet.http.Cookie;
+
+import org.owasp.esapi.ESAPI;
+import org.owasp.esapi.Encoder;
+import org.owasp.esapi.EncoderConstants;
+import org.owasp.esapi.SecurityConfiguration;
+import org.owasp.esapi.ValidationErrorList;
+import org.owasp.esapi.ValidationRule;
+import org.owasp.esapi.Validator;
 import org.owasp.esapi.errors.ValidationException;
 import org.owasp.esapi.filters.SecurityWrapperRequest;
 import org.owasp.esapi.http.MockHttpServletRequest;
@@ -27,12 +44,9 @@ import org.owasp.esapi.reference.validation.HTMLValidationRule;
 import org.owasp.esapi.reference.validation.StringValidationRule;
 import org.owasp.esapi.util.TestUtils;
 
-import javax.servlet.http.Cookie;
-import java.io.*;
-import java.net.URI;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.*;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
 /**
  * The Class ValidatorTest.
@@ -129,49 +143,6 @@ public class ValidatorTest extends TestCase {
         assertTrue(errors.size()==3);
         assertFalse(instance.isValidCreditCard("cctest4", "4417 1234 5678 9112", false, errors));
         assertTrue(errors.size()==4);
-    }
-
-    public void testGetValidDate() throws Exception {
-    	System.out.println("getValidDate");
-    	Validator instance = ESAPI.validator();
-    	ValidationErrorList errors = new ValidationErrorList();
-    	assertTrue(instance.getValidDate("datetest1", "June 23, 1967", DateFormat.getDateInstance(DateFormat.LONG, Locale.US), false) != null);
-    	instance.getValidDate("datetest2", "freakshow", DateFormat.getDateInstance(), false, errors);
-    	assertEquals(1, errors.size());
-
-    	// TODO: This test case fails due to an apparent bug in SimpleDateFormat
-    	// Note: This seems to be fixed in JDK 6. Will leave it commented out since
-    	//		 we only require JDK 5. -kww
-    	instance.getValidDate("test", "June 32, 2008", DateFormat.getDateInstance(DateFormat.DEFAULT, Locale.US), false, errors);
-    	// assertEquals( 2, errors.size() );
-    }
-    
-    // FIXME: Should probably use SecurityConfigurationWrapper and force
-    //		  Validator.AcceptLenientDates to be false.
-    public void testLenientDate() {
-    	System.out.println("testLenientDate");
-    	boolean acceptLenientDates = ESAPI.securityConfiguration().getLenientDatesAccepted();
-    	if ( acceptLenientDates ) {
-    		assertTrue("Lenient date test skipped because Validator.AcceptLenientDates set to true", true);
-    		return;
-    	}
-
-    	Date lenientDateTest = null;
-    	try {
-    		// lenientDateTest will be null when Validator.AcceptLenientDates
-    		// is set to false (the default).
-    		Validator instance = ESAPI.validator();
-    		lenientDateTest = instance.getValidDate("datatest3-lenient", "15/2/2009 11:83:00",
-    				                                DateFormat.getDateInstance(DateFormat.SHORT, Locale.US),
-    				                                false);
-    		fail("Failed to throw expected ValidationException when Validator.AcceptLenientDates set to false.");
-    	} catch (ValidationException ve) {
-    		assertNull( lenientDateTest );
-    		Throwable cause = ve.getCause();
-    		assertTrue( cause.getClass().getName().equals("java.text.ParseException") );
-    	} catch (Exception e) {
-    		fail("Caught unexpected exception: " + e.getClass().getName() + "; msg: " + e);
-    	}
     }
 
     public void testGetValidDirectoryPath() throws Exception {
@@ -312,45 +283,6 @@ public class ValidatorTest extends TestCase {
         assertFalse("Files must have an extension", instance.isValidFileName("test", "", false));
         assertFalse("Files must have a valid extension", instance.isValidFileName("test.invalidExtension", "", false));
         assertFalse("Filennames cannot be the empty string", instance.isValidFileName("test", "", false));
-    }
-
-    public void testIsValidDate() {
-        System.out.println("isValidDate");
-        Validator instance = ESAPI.validator();
-        DateFormat format = SimpleDateFormat.getDateInstance(SimpleDateFormat.LONG, Locale.US);
-        assertTrue(instance.isValidDate("datetest1", "September 11, 2001", format, true));
-        assertFalse(instance.isValidDate("datetest2", null, format, false));
-        assertFalse(instance.isValidDate("datetest3", "", format, false));
-
-        ValidationErrorList errors = new ValidationErrorList();
-        assertTrue(instance.isValidDate("datetest1", "September 11, 2001", format, true, errors));
-        assertTrue(errors.size()==0);
-        assertFalse(instance.isValidDate("datetest2", null, format, false, errors));
-        assertTrue(errors.size()==1);
-        assertFalse(instance.isValidDate("datetest3", "", format, false, errors));
-        assertTrue(errors.size()==2);
-
-    }
-    
-    public void testIsValidDateIssue299() {
-        Validator instance = ESAPI.validator();
-        DateFormat df=new SimpleDateFormat("dd/MM/yyyy");      
-        df.setLenient(true);
-        assertFalse(instance.isValidDate("Pruebas-", "01/01/2aaa", df, false));
-        df=new SimpleDateFormat("yyyy/dd/MM");      
-        df.setLenient(true);
-        assertFalse(instance.isValidDate("Pruebas-", "2aaa/01/01", df, false));
-        df=new SimpleDateFormat("dd/yyyy/MM");      
-        df.setLenient(true);
-        assertFalse(instance.isValidDate("Pruebas-", "01/2012'SELECT * FROM user_table'/01", df, false));
-        df=new SimpleDateFormat("dd/MM/yyyy");      
-        df.setLenient(true);
-        assertFalse(instance.isValidDate("Pruebas-", "01/01/2012'SELECT * FROM user_table'", df, false));
-        df=new SimpleDateFormat("dd/yyyy/MM");      
-        df.setLenient(true);
-        assertFalse(instance.isValidDate("Pruebas-", "01/2aaa/01", df, false));
-        df = SimpleDateFormat.getDateInstance(SimpleDateFormat.LONG, Locale.US);
-        assertFalse(instance.isValidDate("datetest4", "September 11, 2001' union select * from another_table where user_id like '%", df, false));
     }
 
     public void testIsValidDirectoryPath() throws IOException {

--- a/src/test/java/org/owasp/esapi/reference/validation/BaseValidationRuleTest.java
+++ b/src/test/java/org/owasp/esapi/reference/validation/BaseValidationRuleTest.java
@@ -15,87 +15,274 @@
  */
 package org.owasp.esapi.reference.validation;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.core.Is;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.owasp.esapi.Encoder;
+import org.owasp.esapi.ValidationErrorList;
 import org.owasp.esapi.errors.ValidationException;
 
-public class BaseValidationRuleTest extends TestCase {
+public class BaseValidationRuleTest {
+    /**Static Test Data.*/
+    private static final String STR_VAL="";
+    private static final String EX_MSG="Expected Failure Message from " + BaseValidationRuleTest.class.getSimpleName();
+    @Rule
+    public ExpectedException exEx = ExpectedException.none();
 
-	/**
-	 * Instantiates a new base validation rule test.
-	 * 
-	 * @param testName
-	 *            the test name
-	 */
-	public BaseValidationRuleTest(String testName) {
-		super(testName);
-	}
+    private ValidationException testValidationEx = new ValidationException(EX_MSG, EX_MSG);
 
-	/**
-	 * {@inheritDoc}
-	 * 
-	 * @throws Exception
-	 */
-	protected void setUp() throws Exception {
-		// none
-	}
+    private BaseValidationRule uit = mock(BaseValidationRule.class, CALLS_REAL_METHODS);
+    @Test
+    public void testCtrNullTypeName() throws Exception { 
+        String typename = null;
+        BaseValidationRule rule = mock(BaseValidationRule.class, withSettings()
+                .useConstructor(typename)
+                .defaultAnswer(CALLS_REAL_METHODS)
+                );
+        assertNull(rule.getTypeName());
+    }
 
-	/**
-	 * {@inheritDoc}
-	 * 
-	 * @throws Exception
-	 */
-	protected void tearDown() throws Exception {
-		// none
-	}
+    @Test
+    public void testCtrNullEncoder() {
+        String typename = "typename";
+        Encoder encoder = null;
+        BaseValidationRule rule = mock(BaseValidationRule.class, withSettings()
+                .useConstructor(typename, encoder)
+                .defaultAnswer(CALLS_REAL_METHODS)
+                );
+        assertEquals(typename, rule.getTypeName());
+        assertNull(rule.getEncoder());
+    }
+    
+    @Test
+    public void testCtrNullTypenameNullEncoder() {
+        String typename = null;
+        Encoder encoder = null;
+        BaseValidationRule rule = mock(BaseValidationRule.class, withSettings()
+                .useConstructor(typename, encoder)
+                .defaultAnswer(CALLS_REAL_METHODS)
+                );
+        assertNull(rule.getTypeName());
+        assertNull(rule.getEncoder());
+    }
 
-	/**
-	 * Suite.
-	 * 
-	 * @return the test
-	 */
-	public static Test suite() {
-		TestSuite suite = new TestSuite(BaseValidationRuleTest.class);
-		return suite;
-	}
+    @Test
+    public void testCtr2ArgHappyPath() {
+        String typename = "typename";
+        Encoder encoder = mock(Encoder.class);
+        BaseValidationRule rule =  mock(BaseValidationRule.class, withSettings()
+                .useConstructor(typename, encoder)
+                .defaultAnswer(CALLS_REAL_METHODS)
+                );
+        assertEquals(typename, rule.getTypeName());
+        assertEquals(encoder, rule.getEncoder());
+    }
 
-	/**
-	 * Verifies assertValid throws ValidationException on invalid input
-	 * Validates fix for Google issue #195
-	 * 
-	 * @throws ValidationException
-	 */
-	public void testAssertValid() throws ValidationException {
-		SampleValidationRule rule = new SampleValidationRule("UnitTest");
-		try {
-			rule.assertValid("testcontext", "badinput");
-			fail();
-		} catch (ValidationException e) {
-			// success
-		}
-	}
+    @Test
+    public void testCtr1ArgHappyPath() {
+        String typename = "typename";
+        mock(BaseValidationRule.class, withSettings()
+                .useConstructor(typename)
+                .defaultAnswer(CALLS_REAL_METHODS)
+                );
+    }
 
-	public class SampleValidationRule extends BaseValidationRule {
+    @Test
+    public void testSetTypeNameNull() {
+        uit.setTypeName(null); 
+        assertNull(uit.getTypeName());
+    }
 
-		public SampleValidationRule(String typeName, Encoder encoder) {
-			super(typeName, encoder);
-		}
+    @Test
+    public void testSetTypeName() {
+        uit.setTypeName(STR_VAL);
+        assertEquals(STR_VAL, uit.getTypeName());
+    }
 
-		public SampleValidationRule(String typeName) {
-			super(typeName);
-		}
+    @Test
+    public void testSetEncoderNull() {
+        uit.setEncoder(null);
+        assertNull(uit.getEncoder());
+    }
 
-		@Override
-		protected Object sanitize(String context, String input) {
-			return null;
-		}
+    @Test
+    public void testSetEncoder() {
+        Encoder mockEnc = mock(Encoder.class);
+        uit.setEncoder(mockEnc);
+        assertEquals(mockEnc, uit.getEncoder());
+    }
 
-		public Object getValid(String context, String input) throws ValidationException {
-			throw new ValidationException("Demonstration Exception", "Demonstration Exception");
-		}
+    @Test
+    public void testSetAllowNull() {
+        uit.setAllowNull(true);
+        assertTrue(uit.isAllowNull());
+        uit.setAllowNull(false);
+        assertFalse(uit.isAllowNull());
+    }
 
-	}
+    @Test
+    public void testAssertValidCallsGetValid() throws ValidationException {
+        when(uit.getValid(STR_VAL, STR_VAL)).thenReturn(this);
+        uit.assertValid(STR_VAL, STR_VAL);
+        verify(uit, times(1)).getValid(STR_VAL, STR_VAL);
+    }
+    @Test
+    public void testAssertValidThrowsValidationException() throws ValidationException {
+        /*
+         * Verifies assertValid throws ValidationException on invalid input
+         * Validates fix for Google issue #195
+         */
+        Matcher<ValidationException> validationExMatch = Is.is(testValidationEx);
+        exEx.expect(validationExMatch);
+        when(uit.getValid(STR_VAL, STR_VAL)).thenThrow(testValidationEx);
+        uit.assertValid(STR_VAL, STR_VAL);
+    }
+
+    @Test
+    public void testGetValidErrorListCallsGetValid() throws ValidationException {
+        ValidationErrorList vel = new ValidationErrorList();
+        when(uit.getValid(STR_VAL, STR_VAL)).thenReturn(this);
+        Object vRef = uit.getValid(STR_VAL, STR_VAL, vel);
+        assertEquals(this, vRef);
+        verify(uit, times(1)).getValid(STR_VAL, STR_VAL);
+    }
+
+    @Test
+    public void testGetValidExceptionAddedToErrorList() throws ValidationException {
+        ValidationErrorList vel = new ValidationErrorList();
+        when(uit.getValid(STR_VAL, STR_VAL)).thenThrow(testValidationEx);
+        Object vRef = uit.getValid(STR_VAL, STR_VAL, vel);
+        assertNull(vRef);
+        List<ValidationException> elEx = vel.errors();
+        assertEquals(1, elEx.size());
+        assertEquals(testValidationEx, elEx.get(0));
+        verify(uit, times(1)).getValid(STR_VAL, STR_VAL);
+    }
+    @Test
+    public void testGetValidNullErrorListThrows() throws ValidationException {
+        Matcher<ValidationException> validationExMatch = Is.is(testValidationEx);
+        exEx.expect(validationExMatch);
+        ValidationErrorList vel = null;
+        when(uit.getValid(STR_VAL, STR_VAL)).thenThrow(testValidationEx);
+        uit.getValid(STR_VAL, STR_VAL, vel);
+    }
+
+    @Test
+    public void testGetSafeCallsGetValid() throws ValidationException {
+        when(uit.getValid(STR_VAL, STR_VAL)).thenReturn(this);
+        Object vRef = uit.getSafe(STR_VAL, STR_VAL);
+        assertEquals(this, vRef);
+        verify(uit, times(1)).getValid(STR_VAL, STR_VAL);
+    }
+
+    @Test
+    public void testGetSafeOnExceptionCallsSanitize() throws ValidationException {
+        when(uit.getValid(STR_VAL, STR_VAL)).thenThrow(testValidationEx);
+        when(uit.sanitize(STR_VAL, STR_VAL)).thenReturn(this);
+        Object vRef = uit.getSafe(STR_VAL, STR_VAL);
+        assertEquals(this, vRef);
+        verify(uit, times(1)).getValid(STR_VAL, STR_VAL);
+        verify(uit, times(1)).sanitize(STR_VAL, STR_VAL);
+    }
+
+    @Test
+    public void testIsValidCallsGetValid() throws ValidationException {
+        when(uit.getValid(STR_VAL, STR_VAL)).thenReturn(this);
+        assertTrue(uit.isValid(STR_VAL, STR_VAL));
+        verify(uit, times(1)).getValid(STR_VAL, STR_VAL);
+    }
+
+    @Test
+    public void testIsValidOnExceptionRetursFalse() throws ValidationException {
+        when(uit.getValid(STR_VAL, STR_VAL)).thenThrow(testValidationEx);
+        assertFalse(uit.isValid(STR_VAL, STR_VAL));
+        verify(uit, times(1)).getValid(STR_VAL, STR_VAL);
+    }
+
+    /* *************************
+     * TO DISCUSS 
+     * FIXME
+     * Tests below this block are items which are valid against the current implementation, but have side effects
+     * or unclear results under certain conditions.
+     * 
+     * Once Items are discussed and understood they should probably be well-commented and moved out of this area.
+     */
+
+    @Test
+    public void testGetValidMultipleExceptionSameContextThrowsRuntimeException() throws ValidationException {
+        exEx.expect(RuntimeException.class);
+        ValidationErrorList vel = new ValidationErrorList();
+        when(uit.getValid(STR_VAL, STR_VAL)).thenThrow(testValidationEx);
+        uit.getValid(STR_VAL, STR_VAL, vel);
+        /*
+         * Side-effect of ValidationErrorList. If the same context is used against a BaseValidationRule multiple times resulting in exception, the ValidationErrorList impl will blow up.
+         * This can be an unclear event at runtime if a single BaseValidationRule instance is shared in an application and multiple parts happen to use the same contextual string to capture failure events.
+         * 
+         */
+        uit.getValid(STR_VAL, STR_VAL, vel);
+    }
+
+    //None of the Whitelist content belongs in this class, IMO.
+    
+    @Test
+    public void testWhitelistCharArrayCleansString() {
+        String myString = "AAAGaaadBBB12345*";
+        char[] whitelist = new char[] {'d', 'G', '3', '*', ']'};
+        String result = uit.whitelist(myString, whitelist);
+        assertEquals("Gd3*", result);
+    }
+
+    @Test
+    public void testWhitelistNullCharArrayThrows() {
+        exEx.expect(NullPointerException.class);
+        String myString = "AAAGaaadBBB12345*";
+        char[] whitelist = null;
+        uit.whitelist(myString, whitelist);
+    }
+
+    @Test
+    public void testWhitelistSetCleansString() {
+        String myString = "AAAGaaadBBB12345*";
+        Set<Character> whitelist = new HashSet<>();
+        whitelist.add('d');
+        whitelist.add('G');
+        whitelist.add('3');
+        whitelist.add('*');
+        whitelist.add(']');
+        String result = uit.whitelist(myString, whitelist);
+        assertEquals("Gd3*", result);
+    }
+
+    @Test
+    public void testWhitelistNullSetThrows() {
+        exEx.expect(NullPointerException.class);
+        String myString = "AAAGaaadBBB12345*";
+        Set<Character> whitelist = null;
+        uit.whitelist(myString, whitelist);
+    }
+
+    @Test
+    public void testWhitelistSetExtendedCharacterSets() {
+        String myString = "𡘾𦴩<𥻂";
+        //This was an issue wiht HTMLEntityCodec at one point, so it seems like we should be doing this test.
+        fail("I'm not sure how to make this work with : " + myString);
+    }
 }

--- a/src/test/java/org/owasp/esapi/reference/validation/BaseValidationRuleTest.java
+++ b/src/test/java/org/owasp/esapi/reference/validation/BaseValidationRuleTest.java
@@ -33,6 +33,7 @@ import java.util.Set;
 
 import org.hamcrest.Matcher;
 import org.hamcrest.core.Is;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -280,6 +281,7 @@ public class BaseValidationRuleTest {
     }
 
     @Test
+    @Ignore
     public void testWhitelistSetExtendedCharacterSets() {
         String myString = "𡘾𦴩<𥻂";
         //This was an issue wiht HTMLEntityCodec at one point, so it seems like we should be doing this test.

--- a/src/test/java/org/owasp/esapi/reference/validation/BaseValidationRuleTest.java
+++ b/src/test/java/org/owasp/esapi/reference/validation/BaseValidationRuleTest.java
@@ -281,10 +281,15 @@ public class BaseValidationRuleTest {
     }
 
     @Test
-    @Ignore
+    
     public void testWhitelistSetExtendedCharacterSets() {
         String myString = "𡘾𦴩<𥻂";
-        //This was an issue wiht HTMLEntityCodec at one point, so it seems like we should be doing this test.
-        fail("I'm not sure how to make this work with : " + myString);
+        //(55365 56894) (55387 56617) 60 (55383 57026)
+        Set<Character> whitelist = new HashSet<>();
+        whitelist.add((char) 60);
+        whitelist.add((char) 55387);
+        whitelist.add((char) 56617);
+        String result = uit.whitelist(myString, whitelist);
+        assertEquals("𦴩<", result);
     }
 }

--- a/src/test/java/org/owasp/esapi/reference/validation/DateValidationRulePowerMockTest.java
+++ b/src/test/java/org/owasp/esapi/reference/validation/DateValidationRulePowerMockTest.java
@@ -1,0 +1,141 @@
+package org.owasp.esapi.reference.validation;
+
+import java.text.DateFormat;
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.internal.verification.VerificationModeFactory;
+import org.owasp.esapi.Encoder;
+import org.owasp.esapi.SecurityConfiguration;
+import org.owasp.esapi.util.ObjFactory;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ObjFactory.class})
+public class DateValidationRulePowerMockTest {
+    
+    @Rule
+    public TestName testName = new TestName();
+    private Encoder mockEncoder;
+    private DateFormat testFormat = DateFormat.getDateInstance(DateFormat.MEDIUM, Locale.US);
+    private DateValidationRule uit;
+    @Mock
+    private SecurityConfiguration mockSecConfig;
+    
+    @Before
+    public void configureStaticContexts() throws Exception {
+        PowerMockito.mockStatic(ObjFactory.class);
+        PowerMockito.when(ObjFactory.class, "make", ArgumentMatchers.anyString(), ArgumentMatchers.eq("SecurityConfiguration")).thenReturn(mockSecConfig);
+        
+        mockEncoder = Mockito.mock(Encoder.class);
+        testFormat = Mockito.spy(testFormat);
+    }
+    
+    @Test
+    public void testSetDateFormatLenientTrueFromCtr() {
+        Mockito.when(mockSecConfig.getLenientDatesAccepted()).thenReturn(true);
+        
+        testFormat.setLenient(false);
+        Mockito.reset(testFormat);
+        
+        uit = new DateValidationRule(testName.getMethodName(), mockEncoder, testFormat);
+        
+        Assert.assertTrue(testFormat.isLenient());
+       
+        Mockito.verify(mockSecConfig, Mockito.times(1)).getLenientDatesAccepted();
+        Mockito.verify(testFormat, Mockito.times(1)).setLenient(true);
+        Mockito.verify(testFormat, Mockito.times(0)).setLenient(false);
+        
+        PowerMockito.verifyStatic(ObjFactory.class, VerificationModeFactory.times(1));
+        ObjFactory.make(ArgumentMatchers.anyString(), ArgumentMatchers.eq("SecurityConfiguration"));
+        
+        PowerMockito.verifyNoMoreInteractions(ObjFactory.class);
+        
+       
+    }
+    
+    @Test
+    public void testSetDateFormatLenientFalseFromCtr() {
+        Mockito.when(mockSecConfig.getLenientDatesAccepted()).thenReturn(false);
+        
+        testFormat.setLenient(true);
+        Mockito.reset(testFormat);
+        
+        uit = new DateValidationRule(testName.getMethodName(), mockEncoder, testFormat);
+        
+        Assert.assertFalse(testFormat.isLenient());
+       
+        Mockito.verify(mockSecConfig, Mockito.times(1)).getLenientDatesAccepted();
+        Mockito.verify(testFormat, Mockito.times(0)).setLenient(true);
+        Mockito.verify(testFormat, Mockito.times(1)).setLenient(false);
+        
+        PowerMockito.verifyStatic(ObjFactory.class, VerificationModeFactory.times(1));
+        ObjFactory.make(ArgumentMatchers.anyString(), ArgumentMatchers.eq("SecurityConfiguration"));
+        
+        PowerMockito.verifyNoMoreInteractions(ObjFactory.class);
+    }
+    
+    @Test
+    public void testSetDateFormatLenientFalseFromSetter() {
+        Mockito.when(mockSecConfig.getLenientDatesAccepted()).thenReturn(false);
+        
+        uit = new DateValidationRule(testName.getMethodName(), mockEncoder, testFormat);
+        
+        //Configuration is lenient=false
+        testFormat.setLenient(true);
+        Mockito.reset(testFormat, mockSecConfig);
+        Assert.assertTrue(testFormat.isLenient());
+        
+        Mockito.when(mockSecConfig.getLenientDatesAccepted()).thenReturn(false);
+        
+        uit.setDateFormat(testFormat);
+        
+        Assert.assertFalse(testFormat.isLenient());
+        
+        Mockito.verify(mockSecConfig, Mockito.times(1)).getLenientDatesAccepted();
+        Mockito.verify(testFormat, Mockito.times(0)).setLenient(true);
+        Mockito.verify(testFormat, Mockito.times(1)).setLenient(false);
+        
+        PowerMockito.verifyStatic(ObjFactory.class, VerificationModeFactory.times(2));
+        ObjFactory.make(ArgumentMatchers.anyString(), ArgumentMatchers.eq("SecurityConfiguration"));
+        
+        PowerMockito.verifyNoMoreInteractions(ObjFactory.class);
+    }
+    
+    @Test
+    public void testSetDateFormatLenientTrueFromSetter() {
+        Mockito.when(mockSecConfig.getLenientDatesAccepted()).thenReturn(true);
+        
+        uit = new DateValidationRule(testName.getMethodName(), mockEncoder, testFormat);
+        
+        //Configuration is lenient=true
+        testFormat.setLenient(false);
+        Mockito.reset(testFormat, mockSecConfig);
+        Assert.assertFalse(testFormat.isLenient());
+        
+        Mockito.when(mockSecConfig.getLenientDatesAccepted()).thenReturn(true);
+        
+        uit.setDateFormat(testFormat);
+        
+        Assert.assertTrue(testFormat.isLenient());
+        
+        Mockito.verify(mockSecConfig, Mockito.times(1)).getLenientDatesAccepted();
+        Mockito.verify(testFormat, Mockito.times(1)).setLenient(true);
+        Mockito.verify(testFormat, Mockito.times(0)).setLenient(false);
+        
+        PowerMockito.verifyStatic(ObjFactory.class, VerificationModeFactory.times(2));
+        ObjFactory.make(ArgumentMatchers.anyString(), ArgumentMatchers.eq("SecurityConfiguration"));
+        
+        PowerMockito.verifyNoMoreInteractions(ObjFactory.class);
+    }
+}

--- a/src/test/java/org/owasp/esapi/reference/validation/DateValidationRuleTest.java
+++ b/src/test/java/org/owasp/esapi/reference/validation/DateValidationRuleTest.java
@@ -2,8 +2,12 @@ package org.owasp.esapi.reference.validation;
 
 import java.text.DateFormat;
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import org.hamcrest.CustomMatcher;
 import org.junit.Assert;
@@ -12,6 +16,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TestName;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.Encoder;
@@ -28,9 +33,9 @@ public class DateValidationRuleTest {
     public TestName testName = new TestName();
     private ParseException testParseEx = new ParseException("Test Exception", 0);
     private Date testDate = new Date();
-    private String fauxDateString = "I'm A Real Date!";
-    private String canonDateString = "CanonDate";
-  
+    private String dateString;
+    private String canonDateString ;
+    
     private String contextStr;
     private Encoder mockEncoder;
     private DateFormat testFormat = DateFormat.getDateInstance(DateFormat.MEDIUM, Locale.US);
@@ -42,6 +47,9 @@ public class DateValidationRuleTest {
         testFormat = Mockito.spy(testFormat);
         uit = new DateValidationRule(testName.getMethodName(), mockEncoder, testFormat);
         contextStr = testName.getMethodName();
+        
+        dateString = testFormat.format(testDate);
+        canonDateString = dateString;
     }
     @Test
     public void testCtrNullDateFormatThrows() {
@@ -112,18 +120,28 @@ public class DateValidationRuleTest {
             }
         });
         
-        Mockito.when(mockEncoder.canonicalize(fauxDateString)).thenReturn(canonDateString);
+        Mockito.when(mockEncoder.canonicalize(dateString)).thenReturn(canonDateString);
         Mockito.doThrow(testParseEx).when(testFormat).parse(canonDateString);
         
-        uit.getValid(contextStr, fauxDateString);
+        uit.getValid(contextStr, dateString);
     }
     
     @Test
     public void testGetValidHappyPath() throws ValidationException, ParseException {
-        Mockito.when(mockEncoder.canonicalize(fauxDateString)).thenReturn(canonDateString);
+        Mockito.when(mockEncoder.canonicalize(dateString)).thenReturn(canonDateString);
         Mockito.doReturn(testDate).when(testFormat).parse(canonDateString);
         
-        Date date = uit.getValid(contextStr, fauxDateString);
+        Date date = uit.getValid(contextStr, dateString);
+        Assert.assertEquals(testDate, date);
+    }
+    
+    @Test
+    public void testGetValidDateWithCruft() throws ValidationException, ParseException {
+        String cruftyDate = canonDateString + "' union select * from another_table where user_id like '%";
+        Mockito.when(mockEncoder.canonicalize(cruftyDate)).thenReturn(cruftyDate);
+        Mockito.doReturn(testDate).when(testFormat).parse(cruftyDate);
+        
+        Date date = uit.getValid(contextStr, cruftyDate);
         Assert.assertEquals(testDate, date);
     }
     
@@ -151,20 +169,66 @@ public class DateValidationRuleTest {
     
     @Test
     public void testSanitizeBadDateReturnsDefault() throws ValidationException, ParseException {
-        Mockito.when(mockEncoder.canonicalize(fauxDateString)).thenReturn(canonDateString);
+        Mockito.when(mockEncoder.canonicalize(dateString)).thenReturn(canonDateString);
         Mockito.doThrow(testParseEx).when(testFormat).parse(canonDateString);
         
-        Date date =  uit.sanitize(contextStr, fauxDateString);
+        Date date =  uit.sanitize(contextStr, dateString);
         Assert.assertEquals(0, date.getTime());
     }
     
     @Test
     public void testSanitizeHappyPath() throws ValidationException, ParseException {
-        Mockito.when(mockEncoder.canonicalize(fauxDateString)).thenReturn(canonDateString);
+        Mockito.when(mockEncoder.canonicalize(dateString)).thenReturn(canonDateString);
         Mockito.doReturn(testDate).when(testFormat).parse(canonDateString);
         
-        Date date = uit.sanitize(contextStr, fauxDateString);
+        Date date = uit.sanitize(contextStr, dateString);
         Assert.assertEquals(testDate, date);
     }
+    @Test
+    public void testSanitizeDateWithCruft() throws ValidationException, ParseException {
+        String cruftyDate = canonDateString + "' union select * from another_table where user_id like '%";
+        Mockito.when(mockEncoder.canonicalize(cruftyDate)).thenReturn(cruftyDate);
+        Mockito.doReturn(testDate).when(testFormat).parse(cruftyDate);
+        
+        Date date = uit.sanitize(contextStr, cruftyDate);
+        Assert.assertEquals(0, date.getTime());
+    }
     
+    @Test
+    public void testGithubIssue299() throws ParseException, ValidationException {
+        Map<DateFormat, String> formatDateMap = new HashMap<>();
+        formatDateMap.put(new SimpleDateFormat("dd/MM/yyyy"), "01/01/2aaa");
+        formatDateMap.put(new SimpleDateFormat("yyyy/dd/MM"), "2aaa/01/01");
+        formatDateMap.put(new SimpleDateFormat("dd/yyyy/MM"), "01/2012'SELECT * FROM user_table'/01");
+        formatDateMap.put(new SimpleDateFormat("dd/MM/yyyy"),"01/01/2012'SELECT * FROM user_table'");
+        formatDateMap.put(new SimpleDateFormat("dd/yyyy/MM"),"01/2aaa/01");
+        formatDateMap.put(SimpleDateFormat.getDateInstance(SimpleDateFormat.LONG, Locale.US), "September 11, 2001' union select * from another_table where user_id like '%");
+        
+        for (Entry<DateFormat, String> pair : formatDateMap.entrySet()) {
+            String cruftyDate = pair.getValue();
+            Mockito.when(mockEncoder.canonicalize(cruftyDate)).thenReturn(cruftyDate);
+            
+            DateFormat lenientFormat = Mockito.spy(pair.getKey());
+            lenientFormat.setLenient(true);
+            Mockito.doNothing().when(lenientFormat).setLenient(ArgumentMatchers.anyBoolean());
+            Mockito.doReturn(testDate).when(lenientFormat).parse(cruftyDate);
+            
+            DateFormat strictFormat = Mockito.spy(pair.getKey());
+            strictFormat.setLenient(false);
+            Mockito.doNothing().when(strictFormat).setLenient(ArgumentMatchers.anyBoolean());
+            Mockito.doReturn(testDate).when(strictFormat).parse(cruftyDate);
+            
+            uit.setDateFormat(lenientFormat);
+            Date lenientValidDate = uit.getValid(contextStr, cruftyDate);
+            Assert.assertEquals("calls to getValid should not change the parsed date regardless of cruft",testDate, lenientValidDate);
+            Date lenientSanitizedDate = uit.sanitize(contextStr, cruftyDate);
+            Assert.assertEquals("calls to sanitize should return default date if cruft exists in input string",0, lenientSanitizedDate.getTime());
+            
+            uit.setDateFormat(strictFormat);
+            Date strictValidDate = uit.getValid(contextStr, cruftyDate);
+            Assert.assertEquals("calls to getValid should not change the parsed date regardless of cruft",testDate, strictValidDate);
+            Date strictSanitizedDate = uit.sanitize(contextStr, cruftyDate);
+            Assert.assertEquals("calls to sanitize should return default date if cruft exists in input string",0, strictSanitizedDate.getTime());
+        }
+    }
 }

--- a/src/test/java/org/owasp/esapi/reference/validation/DateValidationRuleTest.java
+++ b/src/test/java/org/owasp/esapi/reference/validation/DateValidationRuleTest.java
@@ -20,6 +20,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.Encoder;
+import org.owasp.esapi.ValidationErrorList;
 import org.owasp.esapi.errors.ValidationException;
 import org.owasp.esapi.reference.DefaultSecurityConfiguration;
 import org.powermock.reflect.Whitebox;
@@ -174,6 +175,19 @@ public class DateValidationRuleTest {
         
         Date date =  uit.sanitize(contextStr, dateString);
         Assert.assertEquals(0, date.getTime());
+    }
+    
+    @Test
+    public void testSanitizeErrorListContainsError() throws ValidationException, ParseException {
+        ValidationErrorList vel = new ValidationErrorList();
+        Mockito.when(mockEncoder.canonicalize(dateString)).thenReturn(canonDateString);
+        Mockito.doThrow(testParseEx).when(testFormat).parse(canonDateString);
+        
+        Date date =  uit.sanitize(contextStr, dateString, vel);
+        Assert.assertEquals(0, date.getTime());
+        Assert.assertEquals(1, vel.size());
+        ValidationException wrapper = vel.errors().get(0);
+        Assert.assertEquals(testParseEx, wrapper.getCause());
     }
     
     @Test

--- a/src/test/java/org/owasp/esapi/reference/validation/DateValidationRuleTest.java
+++ b/src/test/java/org/owasp/esapi/reference/validation/DateValidationRuleTest.java
@@ -1,0 +1,170 @@
+package org.owasp.esapi.reference.validation;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.Locale;
+
+import org.hamcrest.CustomMatcher;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TestName;
+import org.mockito.Mockito;
+import org.owasp.esapi.ESAPI;
+import org.owasp.esapi.Encoder;
+import org.owasp.esapi.errors.ValidationException;
+import org.owasp.esapi.reference.DefaultSecurityConfiguration;
+import org.powermock.reflect.Whitebox;
+
+
+public class DateValidationRuleTest {
+    
+    @Rule
+    public ExpectedException exEx = ExpectedException.none();
+    @Rule
+    public TestName testName = new TestName();
+    private ParseException testParseEx = new ParseException("Test Exception", 0);
+    private Date testDate = new Date();
+    private String fauxDateString = "I'm A Real Date!";
+    private String canonDateString = "CanonDate";
+  
+    private String contextStr;
+    private Encoder mockEncoder;
+    private DateFormat testFormat = DateFormat.getDateInstance(DateFormat.MEDIUM, Locale.US);
+    private DateValidationRule uit;
+    
+    @Before
+    public void setup() {
+        mockEncoder = Mockito.mock(Encoder.class);
+        testFormat = Mockito.spy(testFormat);
+        uit = new DateValidationRule(testName.getMethodName(), mockEncoder, testFormat);
+        contextStr = testName.getMethodName();
+    }
+    @Test
+    public void testCtrNullDateFormatThrows() {
+        exEx.expect(IllegalArgumentException.class);
+        exEx.expectMessage("DateValidationRule.setDateFormat requires a non-null DateFormat");
+        new DateValidationRule("context", mockEncoder, null);
+    }
+    
+    @Test
+    public void testCtrSetDateFormat() {
+        DateFormat uitFormat = Whitebox.getInternalState(uit, "format");
+        Assert.assertEquals(testFormat, uitFormat);
+    }
+    
+    @Test
+    public void testsetDateFormatNullThrows() {
+        exEx.expect(IllegalArgumentException.class);
+        exEx.expectMessage("DateValidationRule.setDateFormat requires a non-null DateFormat");
+        uit.setDateFormat(null);
+    }
+    
+    @Test
+    public void testsetDateFormat() {
+        boolean acceptLenient = ESAPI.securityConfiguration().getBooleanProp( DefaultSecurityConfiguration.ACCEPT_LENIENT_DATES);
+        DateFormat newFormat = DateFormat.getDateInstance(DateFormat.SHORT, Locale.US);
+        newFormat.setLenient(!acceptLenient);
+        
+        newFormat = Mockito.spy(newFormat);
+        
+        uit.setDateFormat(newFormat);
+        DateFormat uitFormat = Whitebox.getInternalState(uit, "format");
+        Assert.assertEquals(newFormat, uitFormat);
+        Mockito.verify(newFormat).setLenient(acceptLenient);
+    }
+    
+    @Test
+    public void testGetValidNullInputAllowed() throws ValidationException {
+        uit.setAllowNull(true);
+        Date vDate = uit.getValid(contextStr, null);
+        Assert.assertNull(vDate);
+    }
+    
+    @Test
+    public void testGetValidNullInputNotAllowed() throws ValidationException {
+        exEx.expect(ValidationException.class);
+        exEx.expectMessage("Input date required");
+        uit.setAllowNull(false);
+        uit.getValid(contextStr, null);
+    }
+    
+    @Test
+    public void testGetValidNullInputNotAllowedEmptyString() throws ValidationException {
+        exEx.expect(ValidationException.class);
+        exEx.expectMessage("Input date required");
+        uit.setAllowNull(false);
+        uit.getValid(contextStr, "");
+    }
+    
+    @Test
+    public void testGetValidBadDateThrows() throws ValidationException, ParseException {
+        exEx.expect(ValidationException.class);
+        exEx.expectMessage(contextStr + ": Invalid date");
+        exEx.expectCause(new CustomMatcher<Throwable>("Check for Test Parse Exception") {
+
+            @Override
+            public boolean matches(Object item) {
+               return item.equals(testParseEx);
+            }
+        });
+        
+        Mockito.when(mockEncoder.canonicalize(fauxDateString)).thenReturn(canonDateString);
+        Mockito.doThrow(testParseEx).when(testFormat).parse(canonDateString);
+        
+        uit.getValid(contextStr, fauxDateString);
+    }
+    
+    @Test
+    public void testGetValidHappyPath() throws ValidationException, ParseException {
+        Mockito.when(mockEncoder.canonicalize(fauxDateString)).thenReturn(canonDateString);
+        Mockito.doReturn(testDate).when(testFormat).parse(canonDateString);
+        
+        Date date = uit.getValid(contextStr, fauxDateString);
+        Assert.assertEquals(testDate, date);
+    }
+    
+
+    @Test
+    public void testSanitizeNullInputAllowed() throws ValidationException {
+        uit.setAllowNull(true);
+        Date vDate = uit.sanitize(contextStr, null);
+        Assert.assertNull(vDate);
+    }
+    
+    @Test
+    public void testSanitizeNullInputNotAllowed() throws ValidationException {
+        uit.setAllowNull(false);
+        Date date = uit.sanitize(contextStr, null);
+        Assert.assertEquals(0, date.getTime());
+    }
+    
+    @Test
+    public void testSanitizeNullInputNotAllowedEmptyString() throws ValidationException {
+        uit.setAllowNull(false);
+        Date date = uit.sanitize(contextStr, "");
+        Assert.assertEquals(0, date.getTime());
+    }
+    
+    @Test
+    public void testSanitizeBadDateReturnsDefault() throws ValidationException, ParseException {
+        Mockito.when(mockEncoder.canonicalize(fauxDateString)).thenReturn(canonDateString);
+        Mockito.doThrow(testParseEx).when(testFormat).parse(canonDateString);
+        
+        Date date =  uit.sanitize(contextStr, fauxDateString);
+        Assert.assertEquals(0, date.getTime());
+    }
+    
+    @Test
+    public void testSanitizeHappyPath() throws ValidationException, ParseException {
+        Mockito.when(mockEncoder.canonicalize(fauxDateString)).thenReturn(canonDateString);
+        Mockito.doReturn(testDate).when(testFormat).parse(canonDateString);
+        
+        Date date = uit.sanitize(contextStr, fauxDateString);
+        Assert.assertEquals(testDate, date);
+    }
+    
+}


### PR DESCRIPTION
These commits offer a possible solution to issue #299.
Summary of changes:
  * DateValidationRule API extended to include a new sanitize method which accepts a ValidationErrorList
  * DefaultValidator updated to use the DateValidationRule sanatize method
  * Tests around implementation including sample strings from 299 and 258

The changes to DateValidationRule make a distinction between the getValid and sanitize API's.  getValid will make the best possible effort, given configuration and formatter, to determine if any date can be parsed from the input string with no guarantee of safety or accuracy of the input.  This route relies soley on the backing DateFormat for success.

sanitize extends the getValid behavior by attempting validate that the input can be considered 'safe' for application use.
