### PR TITLE
AbstractAccessReferenceMap Issues #37 #329

### DIFF
--- a/src/main/java/org/owasp/esapi/reference/AbstractAccessReferenceMap.java
+++ b/src/main/java/org/owasp/esapi/reference/AbstractAccessReferenceMap.java
@@ -135,7 +135,7 @@ public abstract class AbstractAccessReferenceMap<K> implements AccessReferenceMa
    /**
    * {@inheritDoc}
    */
-   public <T> K addDirectReference(T direct) {
+   public synchronized <T> K addDirectReference(T direct) {
       if ( dtoi.keySet().contains( direct ) ) {
          return dtoi.get( direct );
       }
@@ -148,7 +148,7 @@ public abstract class AbstractAccessReferenceMap<K> implements AccessReferenceMa
    /**
    * {@inheritDoc}
    */
-   public <T> K removeDirectReference(T direct) throws AccessControlException
+   public synchronized <T> K removeDirectReference(T direct) throws AccessControlException
    {
       K indirect = dtoi.get(direct);
       if ( indirect != null ) {
@@ -181,14 +181,14 @@ public abstract class AbstractAccessReferenceMap<K> implements AccessReferenceMa
    /**
    * {@inheritDoc}
    */
-   public <T> K getIndirectReference(T directReference) {
+   public synchronized <T> K getIndirectReference(T directReference) {
       return dtoi.get(directReference);
    }
 
    /**
    * {@inheritDoc}
    */
-   public <T> T getDirectReference(K indirectReference) throws AccessControlException {
+   public synchronized <T> T getDirectReference(K indirectReference) throws AccessControlException {
       if (itod.containsKey(indirectReference) ) {
          try
          {

--- a/src/main/java/org/owasp/esapi/reference/AbstractAccessReferenceMap.java
+++ b/src/main/java/org/owasp/esapi/reference/AbstractAccessReferenceMap.java
@@ -25,10 +25,26 @@ import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Abstract Implementation of the AccessReferenceMap that is backed by ConcurrentHashMaps to
- * provide a thread-safe implementation of the AccessReferenceMap. Implementations of this
- * abstract class should implement the #getUniqueReference() method.
- *
+ * Abstract Implementation of the AccessReferenceMap.
+ * <br>
+ * Implementation offers default synchronization on all public API 
+ * to assist with thread safety.
+ * <br>
+ * For complex interactions spanning multiple calls, it is recommended 
+ * to add a synchronized block around all invocations to maintain intended data integrity.
+ * 
+ * <pre>
+ * public MyClassUsingAARM {
+ *  private AbstractAccessReferenceMap<Object> aarm;
+ * 
+ *  public void replaceAARMDirect(Object oldDirect, Object newDirect) {
+ *     synchronized (aarm) {
+ *        aarm.removeDirectReference(oldDirect);
+ *        aarm.addDirectReference(newDirect);
+ *     }
+ *  }
+ * }
+ * </pre>
  * @author  Chris Schmidt (chrisisbeef@gmail.com)
  * @since   July 21, 2009
  */

--- a/src/main/java/org/owasp/esapi/reference/AbstractAccessReferenceMap.java
+++ b/src/main/java/org/owasp/esapi/reference/AbstractAccessReferenceMap.java
@@ -15,14 +15,14 @@
  */
 package org.owasp.esapi.reference;
 
-import org.owasp.esapi.AccessReferenceMap;
-import org.owasp.esapi.errors.AccessControlException;
-
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
+
+import org.owasp.esapi.AccessReferenceMap;
+import org.owasp.esapi.errors.AccessControlException;
 
 /**
  * Abstract Implementation of the AccessReferenceMap.
@@ -59,15 +59,15 @@ public abstract class AbstractAccessReferenceMap<K> implements AccessReferenceMa
 
    /**
     * Instantiates a new access reference map. Note that this will create the underlying Maps with an initialSize
-    * of {@link ConcurrentHashMap#DEFAULT_INITIAL_CAPACITY} and that resizing a Map is an expensive process. Consider
+    * of {@link HashMap#DEFAULT_INITIAL_CAPACITY} and that resizing a Map is an expensive process. Consider
     * using a constructor where the initialSize is passed in to maximize performance of the AccessReferenceMap.
     *
     * @see #AbstractAccessReferenceMap(java.util.Set, int)
     * @see #AbstractAccessReferenceMap(int)
     */
    public AbstractAccessReferenceMap() {
-      itod = new ConcurrentHashMap<K, Object>();
-      dtoi = new ConcurrentHashMap<Object,K>();
+      itod = new HashMap<K, Object>();
+      dtoi = new HashMap<Object,K>();
    }
 
    /**
@@ -78,8 +78,8 @@ public abstract class AbstractAccessReferenceMap<K> implements AccessReferenceMa
     *          The initial size of the underlying maps
     */
    public AbstractAccessReferenceMap( int initialSize ) {
-      itod = new ConcurrentHashMap<K, Object>(initialSize);
-      dtoi = new ConcurrentHashMap<Object,K>(initialSize);
+      itod = new HashMap<K, Object>(initialSize);
+      dtoi = new HashMap<Object,K>(initialSize);
    }
 
    /**
@@ -98,8 +98,8 @@ public abstract class AbstractAccessReferenceMap<K> implements AccessReferenceMa
     */
    @Deprecated
    public AbstractAccessReferenceMap( Set<Object> directReferences ) {
-      itod = new ConcurrentHashMap<K, Object>(directReferences.size());
-      dtoi = new ConcurrentHashMap<Object,K>(directReferences.size());
+      itod = new HashMap<K, Object>(directReferences.size());
+      dtoi = new HashMap<Object,K>(directReferences.size());
       update(directReferences);
    }
 
@@ -127,8 +127,8 @@ public abstract class AbstractAccessReferenceMap<K> implements AccessReferenceMa
     */
    @Deprecated
    public AbstractAccessReferenceMap( Set<Object> directReferences, int initialSize ) {
-      itod = new ConcurrentHashMap<K, Object>(initialSize);
-      dtoi = new ConcurrentHashMap<Object,K>(initialSize);
+      itod = new HashMap<K, Object>(initialSize);
+      dtoi = new HashMap<Object,K>(initialSize);
       update(directReferences);
    }
 
@@ -178,8 +178,8 @@ public abstract class AbstractAccessReferenceMap<K> implements AccessReferenceMa
    * {@inheritDoc}
    */
    public final synchronized void update(Set directReferences) {
-      Map<Object,K> new_dtoi = new ConcurrentHashMap<Object,K>( directReferences.size() );
-      Map<K,Object> new_itod = new ConcurrentHashMap<K,Object>( directReferences.size() );
+      Map<Object,K> new_dtoi = new HashMap<Object,K>( directReferences.size() );
+      Map<K,Object> new_itod = new HashMap<K,Object>( directReferences.size() );
 
       for ( Object o : directReferences ) {
          K indirect = dtoi.get( o );

--- a/src/test/java/org/owasp/esapi/reference/AbstractAccessReferenceMapTest.java
+++ b/src/test/java/org/owasp/esapi/reference/AbstractAccessReferenceMapTest.java
@@ -1,7 +1,10 @@
 package org.owasp.esapi.reference;
 
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.powermock.reflect.Whitebox;
@@ -61,5 +64,37 @@ public class AbstractAccessReferenceMapTest {
         lockIndirectRefs.join();
 
         Mockito.verify(map,Mockito.times(1)).getUniqueReference();
+    }
+    
+    @Test
+    public void verifyNoDuplicateKeysOnUpdateReplace() {
+        @SuppressWarnings("unchecked")
+        final AbstractAccessReferenceMap<Object> map = Mockito.mock(AbstractAccessReferenceMap.class, Mockito.withSettings().useConstructor()
+                .defaultAnswer(Mockito.CALLS_REAL_METHODS)
+                );
+        Object indirectObj1 = new Object();
+        Object indirectObj2 = new Object();
+        Mockito.when(map.getUniqueReference()).thenReturn(indirectObj1); 
+        
+        Object direct1 = new Object();
+        Object direct2 = new Object();
+        
+        map.addDirectReference(direct1);
+        
+        Mockito.reset(map);
+        
+        Set<Object> newDirectElements = new HashSet<>();
+        newDirectElements.add(direct2);
+        newDirectElements.add(direct1);
+        
+        Mockito.when(map.getUniqueReference()).thenReturn(indirectObj1).thenReturn(indirectObj2); 
+        
+        map.update(newDirectElements);
+        
+        //Needs to be called 2 times to get past the first duplicate key. This verifies that we're inserting unique pairs.
+        Mockito.verify(map, Mockito.times(2)).getUniqueReference();
+        
+        Assert.assertEquals(indirectObj1, map.getIndirectReference(direct1));
+        Assert.assertEquals(indirectObj2, map.getIndirectReference(direct2));
     }
 }

--- a/src/test/java/org/owasp/esapi/reference/AbstractAccessReferenceMapTest.java
+++ b/src/test/java/org/owasp/esapi/reference/AbstractAccessReferenceMapTest.java
@@ -1,0 +1,65 @@
+package org.owasp.esapi.reference;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.powermock.reflect.Whitebox;
+
+
+public class AbstractAccessReferenceMapTest {
+
+    @Test
+    public void testConcurrentAddDirectReference() throws Exception {
+        @SuppressWarnings("unchecked")
+        final AbstractAccessReferenceMap<Object> map = Mockito.mock(AbstractAccessReferenceMap.class, Mockito.withSettings().useConstructor()
+                .defaultAnswer(Mockito.CALLS_REAL_METHODS)
+                );
+        Object indirectObj = new Object();
+        Mockito.when(map.getUniqueReference()).thenReturn(indirectObj);
+
+        final ConcurrentHashMap<?,?> itod= Whitebox.getInternalState(map, "itod");
+
+        final Object toAdd = new Object();
+
+        Runnable addReference1 = new Runnable() {
+            @Override
+            public void run() {
+                map.addDirectReference(toAdd);
+            }
+        };
+        Runnable addReference2 = new Runnable() {
+            @Override
+            public void run() {
+                map.addDirectReference(toAdd);
+            }
+        };
+
+        Runnable lockItod = new Runnable() {
+            public void run() {
+                synchronized (itod) {
+                    try {
+                        Thread.sleep(2000);
+                    } catch (InterruptedException e) {
+                        // TODO Auto-generated catch block
+                        e.printStackTrace();
+                    }
+
+                } 
+            }
+        };
+
+        Thread lockIndirectRefs = new Thread(lockItod, "Lock Indirect Refs");
+        Thread addRef1Thread = new Thread(addReference1, "Add Ref 1");
+        Thread addRef2Thread = new Thread(addReference2, "Add Ref 2");
+        lockIndirectRefs.start();
+        addRef1Thread.start();
+        addRef2Thread.start();
+
+        addRef1Thread.join();
+        addRef2Thread.join();
+        lockIndirectRefs.join();
+
+        Mockito.verify(map,Mockito.times(1)).getUniqueReference();
+    }
+}

--- a/src/test/java/org/owasp/esapi/reference/AbstractAccessReferenceMapTest.java
+++ b/src/test/java/org/owasp/esapi/reference/AbstractAccessReferenceMapTest.java
@@ -1,6 +1,6 @@
 package org.owasp.esapi.reference;
 
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.HashMap;
 
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -18,7 +18,7 @@ public class AbstractAccessReferenceMapTest {
         Object indirectObj = new Object();
         Mockito.when(map.getUniqueReference()).thenReturn(indirectObj);
 
-        final ConcurrentHashMap<?,?> itod= Whitebox.getInternalState(map, "itod");
+        final HashMap<?,?> itod= Whitebox.getInternalState(map, "itod");
 
         final Object toAdd = new Object();
 


### PR DESCRIPTION
Potential resolutions for two issues in AbstractAccessReferenceMap.

First, handling #329 I've provided a multi-threaded unit test which replicates the condition consistently.  The offered solution is to add *synchronized* keyword to all public API of the AbstractAccessReferenceMap.

Second, #37 Provided a test which shows that in cases where subclasses return the same indirect key multiple times it can lead to corruption during update.  Logic updates were made to the implementation to address.