### PR TITLE
Issue #188 resolution proof:  Test updates

### DIFF
--- a/src/test/java/org/owasp/esapi/filters/SecurityWrapperRequestTest.java
+++ b/src/test/java/org/owasp/esapi/filters/SecurityWrapperRequestTest.java
@@ -386,6 +386,129 @@ public class SecurityWrapperRequestTest {
     }
 
     @Test
+    public void testGetParameterStringBooleanNullEvalPassthrough() throws Exception{
+        String originalParam = "aParameterValue";
+        String parameterName = "SomeParameterName";
+        String cannonicalParam=null;
+
+        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
+
+        String context = anyString();
+        String input = inputCapture.capture();
+        String type = typeCapture.capture();
+        Integer length = lengthCapture.capture();
+        Boolean allowNull = allowNullCapture.capture();
+
+        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
+                cannonicalParam);
+        PowerMockito.when(mockSecConfig.getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME)).thenReturn(
+                SECURITY_CONFIGURATION_TEST_LENGTH);
+
+        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+
+        SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
+        String rval = request.getParameter(parameterName, false);
+        assertNull(rval);
+
+        String actualInput = inputCapture.getValue();
+        String actualType = typeCapture.getValue();
+        int actualLength = lengthCapture.getValue().intValue();
+        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
+
+        assertEquals(originalParam, actualInput);
+        assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
+        assertTrue(SECURITY_CONFIGURATION_TEST_LENGTH == actualLength);
+        assertFalse(actualAllowNull);
+
+        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
+        verify(mockSecConfig, times(1)).getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME);
+        verify(mockRequest, times(1)).getParameter(parameterName);
+    }
+    
+    @Test
+    public void testGetParameterStringBooleanIntNullEvalPassthrough() throws Exception{
+        String originalParam = "aParameterValue";
+        String parameterName = "SomeParameterName";
+        String cannonicalParam=null;
+
+        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
+
+        String context = anyString();
+        String input = inputCapture.capture();
+        String type = typeCapture.capture();
+        Integer length = lengthCapture.capture();
+        Boolean allowNull = allowNullCapture.capture();
+
+        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
+                cannonicalParam);
+        
+        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+
+        SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
+        String rval = request.getParameter(parameterName, false, 75);
+        assertNull(rval);
+
+        String actualInput = inputCapture.getValue();
+        String actualType = typeCapture.getValue();
+        int actualLength = lengthCapture.getValue().intValue();
+        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
+
+        assertEquals(originalParam, actualInput);
+        assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
+        assertTrue(75 == actualLength);
+        assertFalse(actualAllowNull);
+
+        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
+        verify(mockRequest, times(1)).getParameter(parameterName);
+    }
+    
+    @Test
+    public void testGetParameterStringBooleanIntStringNullEvalPassthrough() throws Exception{
+        String originalParam = "aParameterValue";
+        String parameterName = "SomeParameterName";
+        String cannonicalParam=null;
+
+        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
+
+        String context = anyString();
+        String input = inputCapture.capture();
+        String type = typeCapture.capture();
+        Integer length = lengthCapture.capture();
+        Boolean allowNull = allowNullCapture.capture();
+
+        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
+                cannonicalParam);
+        
+        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+
+        SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
+        String rval = request.getParameter(parameterName, false, 75, "customType");
+        assertNull(rval);
+
+        String actualInput = inputCapture.getValue();
+        String actualType = typeCapture.getValue();
+        int actualLength = lengthCapture.getValue().intValue();
+        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
+
+        assertEquals(originalParam, actualInput);
+        assertEquals("customType", actualType);
+        assertTrue(75 == actualLength);
+        assertFalse(actualAllowNull);
+
+        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
+        verify(mockRequest, times(1)).getParameter(parameterName);
+    }
+    
+    @Test
     public void testGetParameterStringNullOnException() throws Exception{
         String originalParam = "aParameterValue";
         String parameterName = "SomeParameterName";
@@ -424,6 +547,126 @@ public class SecurityWrapperRequestTest {
 
         verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
         verify(mockSecConfig, times(1)).getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME);
+        verify(mockRequest, times(1)).getParameter(parameterName);
+    }
+    
+    
+
+    @Test
+    public void testGetParameterStringBooleanNullOnException() throws Exception{
+        String originalParam = "aParameterValue";
+        String parameterName = "SomeParameterName";
+        ValidationException ve = new ValidationException("Thrown from test Scope", "Test Exception is intentional.");
+        
+        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
+
+        String context = anyString();
+        String input = inputCapture.capture();
+        String type = typeCapture.capture();
+        Integer length = lengthCapture.capture();
+        Boolean allowNull = allowNullCapture.capture();
+
+        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenThrow(ve);
+        PowerMockito.when(mockSecConfig.getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME)).thenReturn(
+                SECURITY_CONFIGURATION_TEST_LENGTH);
+
+        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+
+        SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
+        String rval = request.getParameter(parameterName, false);
+        assertNull(rval);
+        
+        String actualInput = inputCapture.getValue();
+        String actualType = typeCapture.getValue();
+        int actualLength = lengthCapture.getValue().intValue();
+        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
+
+        assertEquals(originalParam, actualInput);
+        assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
+        assertTrue(SECURITY_CONFIGURATION_TEST_LENGTH == actualLength);
+        assertFalse(actualAllowNull);
+
+        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
+        verify(mockSecConfig, times(1)).getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME);
+        verify(mockRequest, times(1)).getParameter(parameterName);
+    }
+    
+    @Test
+    public void testGetParameterStringBooleanIntNullOnException() throws Exception{
+        String originalParam = "aParameterValue";
+        String parameterName = "SomeParameterName";
+        ValidationException ve = new ValidationException("Thrown from test Scope", "Test Exception is intentional.");
+        
+        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
+
+        String context = anyString();
+        String input = inputCapture.capture();
+        String type = typeCapture.capture();
+        Integer length = lengthCapture.capture();
+        Boolean allowNull = allowNullCapture.capture();
+
+        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenThrow(ve);
+        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+
+        SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
+        String rval = request.getParameter(parameterName, false, 75);
+        assertNull(rval);
+        
+        String actualInput = inputCapture.getValue();
+        String actualType = typeCapture.getValue();
+        int actualLength = lengthCapture.getValue().intValue();
+        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
+
+        assertEquals(originalParam, actualInput);
+        assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
+        assertTrue(75 == actualLength);
+        assertFalse(actualAllowNull);
+
+        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
+        verify(mockRequest, times(1)).getParameter(parameterName);
+    }
+    
+    @Test
+    public void testGetParameterStringBooleanIntStringNullOnException() throws Exception{
+        String originalParam = "aParameterValue";
+        String parameterName = "SomeParameterName";
+        ValidationException ve = new ValidationException("Thrown from test Scope", "Test Exception is intentional.");
+        
+        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
+
+        String context = anyString();
+        String input = inputCapture.capture();
+        String type = typeCapture.capture();
+        Integer length = lengthCapture.capture();
+        Boolean allowNull = allowNullCapture.capture();
+
+        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenThrow(ve);
+        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+
+        SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
+        String rval = request.getParameter(parameterName, false, 75, "customType");
+        assertNull(rval);
+
+        String actualInput = inputCapture.getValue();
+        String actualType = typeCapture.getValue();
+        int actualLength = lengthCapture.getValue().intValue();
+        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
+
+        assertEquals(originalParam, actualInput);
+        assertEquals("customType", actualType);
+        assertTrue(75 == actualLength);
+        assertFalse(actualAllowNull);
+
+        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
         verify(mockRequest, times(1)).getParameter(parameterName);
     }
 }

--- a/src/test/java/org/owasp/esapi/filters/SecurityWrapperRequestTest.java
+++ b/src/test/java/org/owasp/esapi/filters/SecurityWrapperRequestTest.java
@@ -27,7 +27,9 @@ import static org.mockito.Mockito.verify;
 import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -57,12 +59,16 @@ public class SecurityWrapperRequestTest {
     private static final String ESAPY_SECURITY_CONFIGURATION_GETTER_METHOD_NAME = "securityConfiguration";
     private static final String SECURITY_CONFIGURATION_QUERY_STRING_LENGTH_KEY_NAME = "HttpUtilities.URILENGTH";
     private static final String SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME = "HttpUtilities.httpQueryParamValueLength";
+    
+    private static final String NULL_STRING = null;
 
     private static final int SECURITY_CONFIGURATION_TEST_LENGTH = 255;
 
     private static final String QUERY_STRING_CANONCALIZE_TYPE_KEY = "HTTPQueryString";
     private static final String PARAMETER_STRING_CANONCALIZE_TYPE_KEY = "HTTPParameterValue";
   
+    @Rule
+    public TestName testName = new TestName();
 
     @Mock
     private HttpServletRequest mockRequest;
@@ -70,6 +76,12 @@ public class SecurityWrapperRequestTest {
     private Validator mockValidator;
     @Mock
     private SecurityConfiguration mockSecConfig;
+    
+    private String testParameterName;
+    private String testParameterValue;
+    private String testValueCanonical;
+    private String testValidatorType;
+    private int testMaximumLength;
 
     @Before
     public void setup() throws Exception {
@@ -79,6 +91,12 @@ public class SecurityWrapperRequestTest {
         //Is intrusion detection disabled?  A:  Yes, it is off.  
         //This logic is confusing:  True, the value is False...
         Mockito.when(mockSecConfig.getDisableIntrusionDetection()).thenReturn(true);
+        
+        testParameterName = testName.getMethodName() + "_parameter_name";
+        testParameterValue = testName.getMethodName() + "_parameter_value";  
+        testValueCanonical = testName.getMethodName() + "_value_canonical";
+        testValidatorType = testName.getMethodName() + "_validator_type";
+        testMaximumLength = testName.getMethodName().length();
     }
     
     /**
@@ -177,10 +195,6 @@ public class SecurityWrapperRequestTest {
     }
     @Test
     public void testGetParameterString() throws Exception{
-        String originalParam = "aParameterValue";
-        String parameterName = "SomeParameterName";
-        String cannonicalParam="safeParameterValue";
-
         ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
@@ -193,37 +207,33 @@ public class SecurityWrapperRequestTest {
         Boolean allowNull = allowNullCapture.capture();
 
         PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
-                cannonicalParam);
+                testValueCanonical);
         PowerMockito.when(mockSecConfig.getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME)).thenReturn(
                 SECURITY_CONFIGURATION_TEST_LENGTH);
 
-        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+        PowerMockito.when(mockRequest.getParameter(testParameterName)).thenReturn(testParameterValue);
 
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
-        String rval = request.getParameter(parameterName);
-        assertEquals(cannonicalParam, rval);
+        String rval = request.getParameter(testParameterName);
+        assertEquals(testValueCanonical, rval);
 
         String actualInput = inputCapture.getValue();
         String actualType = typeCapture.getValue();
         int actualLength = lengthCapture.getValue().intValue();
         boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
 
-        assertEquals(originalParam, actualInput);
+        assertEquals(testParameterValue, actualInput);
         assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
         assertTrue(SECURITY_CONFIGURATION_TEST_LENGTH == actualLength);
         assertTrue(actualAllowNull);
 
         verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
         verify(mockSecConfig, times(1)).getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME);
-        verify(mockRequest, times(1)).getParameter(parameterName);
+        verify(mockRequest, times(1)).getParameter(testParameterName);
     }
 
     @Test
     public void testGetParameterStringBoolean() throws Exception{
-        String originalParam = "aParameterValue";
-        String parameterName = "SomeParameterName";
-        String cannonicalParam="safeParameterValue";
-
         ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
@@ -236,37 +246,33 @@ public class SecurityWrapperRequestTest {
         Boolean allowNull = allowNullCapture.capture();
 
         PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
-                cannonicalParam);
+                testValueCanonical);
         PowerMockito.when(mockSecConfig.getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME)).thenReturn(
                 SECURITY_CONFIGURATION_TEST_LENGTH);
 
-        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+        PowerMockito.when(mockRequest.getParameter(testParameterName)).thenReturn(testParameterValue);
 
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
-        String rval = request.getParameter(parameterName, false);
-        assertEquals(cannonicalParam, rval);
+        String rval = request.getParameter(testParameterName, false);
+        assertEquals(testValueCanonical, rval);
 
         String actualInput = inputCapture.getValue();
         String actualType = typeCapture.getValue();
         int actualLength = lengthCapture.getValue().intValue();
         boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
 
-        assertEquals(originalParam, actualInput);
+        assertEquals(testParameterValue, actualInput);
         assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
         assertTrue(SECURITY_CONFIGURATION_TEST_LENGTH == actualLength);
         assertFalse(actualAllowNull);
 
         verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
         verify(mockSecConfig, times(1)).getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME);
-        verify(mockRequest, times(1)).getParameter(parameterName);
+        verify(mockRequest, times(1)).getParameter(testParameterName);
     }
     
     @Test
     public void testGetParameterStringBooleanInt() throws Exception{
-        String originalParam = "aParameterValue";
-        String parameterName = "SomeParameterName";
-        String cannonicalParam="safeParameterValue";
-
         ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
@@ -279,34 +285,30 @@ public class SecurityWrapperRequestTest {
         Boolean allowNull = allowNullCapture.capture();
 
         PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
-                cannonicalParam);
+                testValueCanonical);
         
-        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+        PowerMockito.when(mockRequest.getParameter(testParameterName)).thenReturn(testParameterValue);
 
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
-        String rval = request.getParameter(parameterName, false, 75);
-        assertEquals(cannonicalParam, rval);
+        String rval = request.getParameter(testParameterName, false, testMaximumLength);
+        assertEquals(testValueCanonical, rval);
 
         String actualInput = inputCapture.getValue();
         String actualType = typeCapture.getValue();
         int actualLength = lengthCapture.getValue().intValue();
         boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
 
-        assertEquals(originalParam, actualInput);
+        assertEquals(testParameterValue, actualInput);
         assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
-        assertTrue(75 == actualLength);
+        assertTrue(testMaximumLength == actualLength);
         assertFalse(actualAllowNull);
 
         verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
-        verify(mockRequest, times(1)).getParameter(parameterName);
+        verify(mockRequest, times(1)).getParameter(testParameterName);
     }
     
     @Test
     public void testGetParameterStringBooleanIntString() throws Exception{
-        String originalParam = "aParameterValue";
-        String parameterName = "SomeParameterName";
-        String cannonicalParam="safeParameterValue";
-
         ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
@@ -319,35 +321,31 @@ public class SecurityWrapperRequestTest {
         Boolean allowNull = allowNullCapture.capture();
 
         PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
-                cannonicalParam);
+                testValueCanonical);
         
-        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+        PowerMockito.when(mockRequest.getParameter(testParameterName)).thenReturn(testParameterValue);
 
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
-        String rval = request.getParameter(parameterName, false, 75, "customType");
-        assertEquals(cannonicalParam, rval);
+        String rval = request.getParameter(testParameterName, false, testMaximumLength, testValidatorType);
+        assertEquals(testValueCanonical, rval);
 
         String actualInput = inputCapture.getValue();
         String actualType = typeCapture.getValue();
         int actualLength = lengthCapture.getValue().intValue();
         boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
 
-        assertEquals(originalParam, actualInput);
-        assertEquals("customType", actualType);
-        assertTrue(75 == actualLength);
+        assertEquals(testParameterValue, actualInput);
+        assertEquals(testValidatorType, actualType);
+        assertTrue(testMaximumLength == actualLength);
         assertFalse(actualAllowNull);
 
         verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
-        verify(mockRequest, times(1)).getParameter(parameterName);
+        verify(mockRequest, times(1)).getParameter(testParameterName);
     }
 
     
     @Test
     public void testGetParameterStringNullEvalPassthrough() throws Exception{
-        String originalParam = "aParameterValue";
-        String parameterName = "SomeParameterName";
-        String cannonicalParam=null;
-
         ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
@@ -360,14 +358,14 @@ public class SecurityWrapperRequestTest {
         Boolean allowNull = allowNullCapture.capture();
 
         PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
-                cannonicalParam);
+                NULL_STRING);
         PowerMockito.when(mockSecConfig.getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME)).thenReturn(
                 SECURITY_CONFIGURATION_TEST_LENGTH);
 
-        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+        PowerMockito.when(mockRequest.getParameter(testParameterName)).thenReturn(testParameterValue);
 
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
-        String rval = request.getParameter(parameterName);
+        String rval = request.getParameter(testParameterName);
         assertNull(rval);
 
         String actualInput = inputCapture.getValue();
@@ -375,22 +373,18 @@ public class SecurityWrapperRequestTest {
         int actualLength = lengthCapture.getValue().intValue();
         boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
 
-        assertEquals(originalParam, actualInput);
+        assertEquals(testParameterValue, actualInput);
         assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
         assertTrue(SECURITY_CONFIGURATION_TEST_LENGTH == actualLength);
         assertTrue(actualAllowNull);
 
         verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
         verify(mockSecConfig, times(1)).getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME);
-        verify(mockRequest, times(1)).getParameter(parameterName);
+        verify(mockRequest, times(1)).getParameter(testParameterName);
     }
 
     @Test
     public void testGetParameterStringBooleanNullEvalPassthrough() throws Exception{
-        String originalParam = "aParameterValue";
-        String parameterName = "SomeParameterName";
-        String cannonicalParam=null;
-
         ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
@@ -403,14 +397,14 @@ public class SecurityWrapperRequestTest {
         Boolean allowNull = allowNullCapture.capture();
 
         PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
-                cannonicalParam);
+                NULL_STRING);
         PowerMockito.when(mockSecConfig.getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME)).thenReturn(
                 SECURITY_CONFIGURATION_TEST_LENGTH);
 
-        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+        PowerMockito.when(mockRequest.getParameter(testParameterName)).thenReturn(testParameterValue);
 
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
-        String rval = request.getParameter(parameterName, false);
+        String rval = request.getParameter(testParameterName, false);
         assertNull(rval);
 
         String actualInput = inputCapture.getValue();
@@ -418,22 +412,18 @@ public class SecurityWrapperRequestTest {
         int actualLength = lengthCapture.getValue().intValue();
         boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
 
-        assertEquals(originalParam, actualInput);
+        assertEquals(testParameterValue, actualInput);
         assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
         assertTrue(SECURITY_CONFIGURATION_TEST_LENGTH == actualLength);
         assertFalse(actualAllowNull);
 
         verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
         verify(mockSecConfig, times(1)).getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME);
-        verify(mockRequest, times(1)).getParameter(parameterName);
+        verify(mockRequest, times(1)).getParameter(testParameterName);
     }
     
     @Test
     public void testGetParameterStringBooleanIntNullEvalPassthrough() throws Exception{
-        String originalParam = "aParameterValue";
-        String parameterName = "SomeParameterName";
-        String cannonicalParam=null;
-
         ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
@@ -446,12 +436,12 @@ public class SecurityWrapperRequestTest {
         Boolean allowNull = allowNullCapture.capture();
 
         PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
-                cannonicalParam);
+                NULL_STRING);
         
-        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+        PowerMockito.when(mockRequest.getParameter(testParameterName)).thenReturn(testParameterValue);
 
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
-        String rval = request.getParameter(parameterName, false, 75);
+        String rval = request.getParameter(testParameterName, false, testMaximumLength);
         assertNull(rval);
 
         String actualInput = inputCapture.getValue();
@@ -459,21 +449,17 @@ public class SecurityWrapperRequestTest {
         int actualLength = lengthCapture.getValue().intValue();
         boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
 
-        assertEquals(originalParam, actualInput);
+        assertEquals(testParameterValue, actualInput);
         assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
-        assertTrue(75 == actualLength);
+        assertTrue(testMaximumLength == actualLength);
         assertFalse(actualAllowNull);
 
         verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
-        verify(mockRequest, times(1)).getParameter(parameterName);
+        verify(mockRequest, times(1)).getParameter(testParameterName);
     }
     
     @Test
     public void testGetParameterStringBooleanIntStringNullEvalPassthrough() throws Exception{
-        String originalParam = "aParameterValue";
-        String parameterName = "SomeParameterName";
-        String cannonicalParam=null;
-
         ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
@@ -486,12 +472,12 @@ public class SecurityWrapperRequestTest {
         Boolean allowNull = allowNullCapture.capture();
 
         PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
-                cannonicalParam);
+                NULL_STRING);
         
-        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+        PowerMockito.when(mockRequest.getParameter(testParameterName)).thenReturn(testParameterValue);
 
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
-        String rval = request.getParameter(parameterName, false, 75, "customType");
+        String rval = request.getParameter(testParameterName, false, testMaximumLength, testValidatorType);
         assertNull(rval);
 
         String actualInput = inputCapture.getValue();
@@ -499,19 +485,17 @@ public class SecurityWrapperRequestTest {
         int actualLength = lengthCapture.getValue().intValue();
         boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
 
-        assertEquals(originalParam, actualInput);
-        assertEquals("customType", actualType);
-        assertTrue(75 == actualLength);
+        assertEquals(testParameterValue, actualInput);
+        assertEquals(testValidatorType, actualType);
+        assertTrue(testMaximumLength == actualLength);
         assertFalse(actualAllowNull);
 
         verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
-        verify(mockRequest, times(1)).getParameter(parameterName);
+        verify(mockRequest, times(1)).getParameter(testParameterName);
     }
     
     @Test
     public void testGetParameterStringNullOnException() throws Exception{
-        String originalParam = "aParameterValue";
-        String parameterName = "SomeParameterName";
         ValidationException ve = new ValidationException("Thrown from test Scope", "Test Exception is intentional.");
 
         ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
@@ -529,10 +513,10 @@ public class SecurityWrapperRequestTest {
         PowerMockito.when(mockSecConfig.getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME)).thenReturn(
                 SECURITY_CONFIGURATION_TEST_LENGTH);
 
-        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+        PowerMockito.when(mockRequest.getParameter(testParameterName)).thenReturn(testParameterValue);
 
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
-        String rval = request.getParameter(parameterName);
+        String rval = request.getParameter(testParameterName);
         assertNull(rval);
 
         String actualInput = inputCapture.getValue();
@@ -540,22 +524,20 @@ public class SecurityWrapperRequestTest {
         int actualLength = lengthCapture.getValue().intValue();
         boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
 
-        assertEquals(originalParam, actualInput);
+        assertEquals(testParameterValue, actualInput);
         assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
         assertTrue(SECURITY_CONFIGURATION_TEST_LENGTH == actualLength);
         assertTrue(actualAllowNull);
 
         verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
         verify(mockSecConfig, times(1)).getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME);
-        verify(mockRequest, times(1)).getParameter(parameterName);
+        verify(mockRequest, times(1)).getParameter(testParameterName);
     }
     
     
 
     @Test
     public void testGetParameterStringBooleanNullOnException() throws Exception{
-        String originalParam = "aParameterValue";
-        String parameterName = "SomeParameterName";
         ValidationException ve = new ValidationException("Thrown from test Scope", "Test Exception is intentional.");
         
         ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
@@ -573,10 +555,10 @@ public class SecurityWrapperRequestTest {
         PowerMockito.when(mockSecConfig.getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME)).thenReturn(
                 SECURITY_CONFIGURATION_TEST_LENGTH);
 
-        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+        PowerMockito.when(mockRequest.getParameter(testParameterName)).thenReturn(testParameterValue);
 
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
-        String rval = request.getParameter(parameterName, false);
+        String rval = request.getParameter(testParameterName, false);
         assertNull(rval);
         
         String actualInput = inputCapture.getValue();
@@ -584,20 +566,18 @@ public class SecurityWrapperRequestTest {
         int actualLength = lengthCapture.getValue().intValue();
         boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
 
-        assertEquals(originalParam, actualInput);
+        assertEquals(testParameterValue, actualInput);
         assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
         assertTrue(SECURITY_CONFIGURATION_TEST_LENGTH == actualLength);
         assertFalse(actualAllowNull);
 
         verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
         verify(mockSecConfig, times(1)).getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME);
-        verify(mockRequest, times(1)).getParameter(parameterName);
+        verify(mockRequest, times(1)).getParameter(testParameterName);
     }
     
     @Test
     public void testGetParameterStringBooleanIntNullOnException() throws Exception{
-        String originalParam = "aParameterValue";
-        String parameterName = "SomeParameterName";
         ValidationException ve = new ValidationException("Thrown from test Scope", "Test Exception is intentional.");
         
         ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
@@ -612,10 +592,10 @@ public class SecurityWrapperRequestTest {
         Boolean allowNull = allowNullCapture.capture();
 
         PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenThrow(ve);
-        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+        PowerMockito.when(mockRequest.getParameter(testParameterName)).thenReturn(testParameterValue);
 
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
-        String rval = request.getParameter(parameterName, false, 75);
+        String rval = request.getParameter(testParameterName, false, testMaximumLength);
         assertNull(rval);
         
         String actualInput = inputCapture.getValue();
@@ -623,19 +603,17 @@ public class SecurityWrapperRequestTest {
         int actualLength = lengthCapture.getValue().intValue();
         boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
 
-        assertEquals(originalParam, actualInput);
+        assertEquals(testParameterValue, actualInput);
         assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
-        assertTrue(75 == actualLength);
+        assertTrue(testMaximumLength == actualLength);
         assertFalse(actualAllowNull);
 
         verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
-        verify(mockRequest, times(1)).getParameter(parameterName);
+        verify(mockRequest, times(1)).getParameter(testParameterName);
     }
     
     @Test
     public void testGetParameterStringBooleanIntStringNullOnException() throws Exception{
-        String originalParam = "aParameterValue";
-        String parameterName = "SomeParameterName";
         ValidationException ve = new ValidationException("Thrown from test Scope", "Test Exception is intentional.");
         
         ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
@@ -650,10 +628,10 @@ public class SecurityWrapperRequestTest {
         Boolean allowNull = allowNullCapture.capture();
 
         PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenThrow(ve);
-        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+        PowerMockito.when(mockRequest.getParameter(testParameterName)).thenReturn(testParameterValue);
 
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
-        String rval = request.getParameter(parameterName, false, 75, "customType");
+        String rval = request.getParameter(testParameterName, false, testMaximumLength, testValidatorType);
         assertNull(rval);
 
         String actualInput = inputCapture.getValue();
@@ -661,12 +639,12 @@ public class SecurityWrapperRequestTest {
         int actualLength = lengthCapture.getValue().intValue();
         boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
 
-        assertEquals(originalParam, actualInput);
-        assertEquals("customType", actualType);
-        assertTrue(75 == actualLength);
+        assertEquals(testParameterValue, actualInput);
+        assertEquals(testValidatorType, actualType);
+        assertTrue(testMaximumLength == actualLength);
         assertFalse(actualAllowNull);
 
         verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
-        verify(mockRequest, times(1)).getParameter(parameterName);
+        verify(mockRequest, times(1)).getParameter(testParameterName);
     }
 }

--- a/src/test/java/org/owasp/esapi/filters/SecurityWrapperRequestTest.java
+++ b/src/test/java/org/owasp/esapi/filters/SecurityWrapperRequestTest.java
@@ -32,8 +32,11 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.SecurityConfiguration;
 import org.owasp.esapi.Validator;
@@ -195,19 +198,9 @@ public class SecurityWrapperRequestTest {
     }
     @Test
     public void testGetParameterString() throws Exception{
-        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
-        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
-
-        String context = anyString();
-        String input = inputCapture.capture();
-        String type = typeCapture.capture();
-        Integer length = lengthCapture.capture();
-        Boolean allowNull = allowNullCapture.capture();
-
-        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
-                testValueCanonical);
+        ValidatorTestContainer validatorTester = new ValidatorTestContainer(mockValidator);
+        validatorTester.getValidInputReturns(testValueCanonical);
+        
         PowerMockito.when(mockSecConfig.getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME)).thenReturn(
                 SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -216,37 +209,17 @@ public class SecurityWrapperRequestTest {
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
         String rval = request.getParameter(testParameterName);
         assertEquals(testValueCanonical, rval);
-
-        String actualInput = inputCapture.getValue();
-        String actualType = typeCapture.getValue();
-        int actualLength = lengthCapture.getValue().intValue();
-        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
-
-        assertEquals(testParameterValue, actualInput);
-        assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
-        assertTrue(SECURITY_CONFIGURATION_TEST_LENGTH == actualLength);
-        assertTrue(actualAllowNull);
-
-        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
+        
+        validatorTester.verify(testParameterValue, PARAMETER_STRING_CANONCALIZE_TYPE_KEY, SECURITY_CONFIGURATION_TEST_LENGTH, true);
+        
         verify(mockSecConfig, times(1)).getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME);
         verify(mockRequest, times(1)).getParameter(testParameterName);
     }
 
     @Test
     public void testGetParameterStringBoolean() throws Exception{
-        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
-        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
-
-        String context = anyString();
-        String input = inputCapture.capture();
-        String type = typeCapture.capture();
-        Integer length = lengthCapture.capture();
-        Boolean allowNull = allowNullCapture.capture();
-
-        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
-                testValueCanonical);
+        ValidatorTestContainer validatorTester = new ValidatorTestContainer(mockValidator);
+        validatorTester.getValidInputReturns(testValueCanonical);
         PowerMockito.when(mockSecConfig.getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME)).thenReturn(
                 SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -255,37 +228,17 @@ public class SecurityWrapperRequestTest {
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
         String rval = request.getParameter(testParameterName, false);
         assertEquals(testValueCanonical, rval);
-
-        String actualInput = inputCapture.getValue();
-        String actualType = typeCapture.getValue();
-        int actualLength = lengthCapture.getValue().intValue();
-        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
-
-        assertEquals(testParameterValue, actualInput);
-        assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
-        assertTrue(SECURITY_CONFIGURATION_TEST_LENGTH == actualLength);
-        assertFalse(actualAllowNull);
-
-        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
+        
+        validatorTester.verify(testParameterValue, PARAMETER_STRING_CANONCALIZE_TYPE_KEY, SECURITY_CONFIGURATION_TEST_LENGTH, false);
+        
         verify(mockSecConfig, times(1)).getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME);
         verify(mockRequest, times(1)).getParameter(testParameterName);
     }
     
     @Test
     public void testGetParameterStringBooleanInt() throws Exception{
-        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
-        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
-
-        String context = anyString();
-        String input = inputCapture.capture();
-        String type = typeCapture.capture();
-        Integer length = lengthCapture.capture();
-        Boolean allowNull = allowNullCapture.capture();
-
-        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
-                testValueCanonical);
+        ValidatorTestContainer validatorTester = new ValidatorTestContainer(mockValidator);
+        validatorTester.getValidInputReturns(testValueCanonical);
         
         PowerMockito.when(mockRequest.getParameter(testParameterName)).thenReturn(testParameterValue);
 
@@ -293,35 +246,16 @@ public class SecurityWrapperRequestTest {
         String rval = request.getParameter(testParameterName, false, testMaximumLength);
         assertEquals(testValueCanonical, rval);
 
-        String actualInput = inputCapture.getValue();
-        String actualType = typeCapture.getValue();
-        int actualLength = lengthCapture.getValue().intValue();
-        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
+        validatorTester.verify(testParameterValue, PARAMETER_STRING_CANONCALIZE_TYPE_KEY, testMaximumLength, false);
 
-        assertEquals(testParameterValue, actualInput);
-        assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
-        assertTrue(testMaximumLength == actualLength);
-        assertFalse(actualAllowNull);
-
-        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
         verify(mockRequest, times(1)).getParameter(testParameterName);
     }
     
     @Test
     public void testGetParameterStringBooleanIntString() throws Exception{
-        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
-        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
-
-        String context = anyString();
-        String input = inputCapture.capture();
-        String type = typeCapture.capture();
-        Integer length = lengthCapture.capture();
-        Boolean allowNull = allowNullCapture.capture();
-
-        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
-                testValueCanonical);
+        ValidatorTestContainer validatorTester = new ValidatorTestContainer(mockValidator);
+        validatorTester.getValidInputReturns(testValueCanonical);
+      
         
         PowerMockito.when(mockRequest.getParameter(testParameterName)).thenReturn(testParameterValue);
 
@@ -329,36 +263,17 @@ public class SecurityWrapperRequestTest {
         String rval = request.getParameter(testParameterName, false, testMaximumLength, testValidatorType);
         assertEquals(testValueCanonical, rval);
 
-        String actualInput = inputCapture.getValue();
-        String actualType = typeCapture.getValue();
-        int actualLength = lengthCapture.getValue().intValue();
-        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
-
-        assertEquals(testParameterValue, actualInput);
-        assertEquals(testValidatorType, actualType);
-        assertTrue(testMaximumLength == actualLength);
-        assertFalse(actualAllowNull);
-
-        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
+        validatorTester.verify(testParameterValue, testValidatorType, testMaximumLength, false);
+     
         verify(mockRequest, times(1)).getParameter(testParameterName);
     }
 
     
     @Test
     public void testGetParameterStringNullEvalPassthrough() throws Exception{
-        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
-        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
-
-        String context = anyString();
-        String input = inputCapture.capture();
-        String type = typeCapture.capture();
-        Integer length = lengthCapture.capture();
-        Boolean allowNull = allowNullCapture.capture();
-
-        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
-                NULL_STRING);
+        ValidatorTestContainer validatorTester = new ValidatorTestContainer(mockValidator);
+        validatorTester.getValidInputReturns(null);
+        
         PowerMockito.when(mockSecConfig.getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME)).thenReturn(
                 SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -367,37 +282,18 @@ public class SecurityWrapperRequestTest {
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
         String rval = request.getParameter(testParameterName);
         assertNull(rval);
+        
+        validatorTester.verify(testParameterValue, PARAMETER_STRING_CANONCALIZE_TYPE_KEY, SECURITY_CONFIGURATION_TEST_LENGTH, true);
 
-        String actualInput = inputCapture.getValue();
-        String actualType = typeCapture.getValue();
-        int actualLength = lengthCapture.getValue().intValue();
-        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
-
-        assertEquals(testParameterValue, actualInput);
-        assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
-        assertTrue(SECURITY_CONFIGURATION_TEST_LENGTH == actualLength);
-        assertTrue(actualAllowNull);
-
-        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
         verify(mockSecConfig, times(1)).getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME);
         verify(mockRequest, times(1)).getParameter(testParameterName);
     }
 
     @Test
     public void testGetParameterStringBooleanNullEvalPassthrough() throws Exception{
-        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
-        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
-
-        String context = anyString();
-        String input = inputCapture.capture();
-        String type = typeCapture.capture();
-        Integer length = lengthCapture.capture();
-        Boolean allowNull = allowNullCapture.capture();
-
-        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
-                NULL_STRING);
+        ValidatorTestContainer validatorTester = new ValidatorTestContainer(mockValidator);
+        validatorTester.getValidInputReturns(null);
+        
         PowerMockito.when(mockSecConfig.getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME)).thenReturn(
                 SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -406,110 +302,49 @@ public class SecurityWrapperRequestTest {
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
         String rval = request.getParameter(testParameterName, false);
         assertNull(rval);
+        
+        validatorTester.verify(testParameterValue, PARAMETER_STRING_CANONCALIZE_TYPE_KEY, SECURITY_CONFIGURATION_TEST_LENGTH, false);
 
-        String actualInput = inputCapture.getValue();
-        String actualType = typeCapture.getValue();
-        int actualLength = lengthCapture.getValue().intValue();
-        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
-
-        assertEquals(testParameterValue, actualInput);
-        assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
-        assertTrue(SECURITY_CONFIGURATION_TEST_LENGTH == actualLength);
-        assertFalse(actualAllowNull);
-
-        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
         verify(mockSecConfig, times(1)).getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME);
         verify(mockRequest, times(1)).getParameter(testParameterName);
     }
     
     @Test
     public void testGetParameterStringBooleanIntNullEvalPassthrough() throws Exception{
-        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
-        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
-
-        String context = anyString();
-        String input = inputCapture.capture();
-        String type = typeCapture.capture();
-        Integer length = lengthCapture.capture();
-        Boolean allowNull = allowNullCapture.capture();
-
-        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
-                NULL_STRING);
+        ValidatorTestContainer validatorTester = new ValidatorTestContainer(mockValidator);
+        validatorTester.getValidInputReturns(null);
         
         PowerMockito.when(mockRequest.getParameter(testParameterName)).thenReturn(testParameterValue);
 
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
         String rval = request.getParameter(testParameterName, false, testMaximumLength);
         assertNull(rval);
+        
+        validatorTester.verify(testParameterValue, PARAMETER_STRING_CANONCALIZE_TYPE_KEY, testMaximumLength, false);
 
-        String actualInput = inputCapture.getValue();
-        String actualType = typeCapture.getValue();
-        int actualLength = lengthCapture.getValue().intValue();
-        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
-
-        assertEquals(testParameterValue, actualInput);
-        assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
-        assertTrue(testMaximumLength == actualLength);
-        assertFalse(actualAllowNull);
-
-        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
         verify(mockRequest, times(1)).getParameter(testParameterName);
     }
     
     @Test
     public void testGetParameterStringBooleanIntStringNullEvalPassthrough() throws Exception{
-        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
-        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
-
-        String context = anyString();
-        String input = inputCapture.capture();
-        String type = typeCapture.capture();
-        Integer length = lengthCapture.capture();
-        Boolean allowNull = allowNullCapture.capture();
-
-        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
-                NULL_STRING);
+        ValidatorTestContainer validatorTester = new ValidatorTestContainer(mockValidator);
+        validatorTester.getValidInputReturns(null);
         
         PowerMockito.when(mockRequest.getParameter(testParameterName)).thenReturn(testParameterValue);
 
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
         String rval = request.getParameter(testParameterName, false, testMaximumLength, testValidatorType);
         assertNull(rval);
+        validatorTester.verify(testParameterValue, testValidatorType, testMaximumLength, false);
 
-        String actualInput = inputCapture.getValue();
-        String actualType = typeCapture.getValue();
-        int actualLength = lengthCapture.getValue().intValue();
-        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
-
-        assertEquals(testParameterValue, actualInput);
-        assertEquals(testValidatorType, actualType);
-        assertTrue(testMaximumLength == actualLength);
-        assertFalse(actualAllowNull);
-
-        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
         verify(mockRequest, times(1)).getParameter(testParameterName);
     }
     
     @Test
     public void testGetParameterStringNullOnException() throws Exception{
-        ValidationException ve = new ValidationException("Thrown from test Scope", "Test Exception is intentional.");
-
-        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
-        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
-
-        String context = anyString();
-        String input = inputCapture.capture();
-        String type = typeCapture.capture();
-        Integer length = lengthCapture.capture();
-        Boolean allowNull = allowNullCapture.capture();
-
-        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenThrow(ve);
+        ValidatorTestContainer validatorTester = new ValidatorTestContainer(mockValidator);
+        validatorTester.getValidInputThrows();
+        
         PowerMockito.when(mockSecConfig.getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME)).thenReturn(
                 SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -519,17 +354,8 @@ public class SecurityWrapperRequestTest {
         String rval = request.getParameter(testParameterName);
         assertNull(rval);
 
-        String actualInput = inputCapture.getValue();
-        String actualType = typeCapture.getValue();
-        int actualLength = lengthCapture.getValue().intValue();
-        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
-
-        assertEquals(testParameterValue, actualInput);
-        assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
-        assertTrue(SECURITY_CONFIGURATION_TEST_LENGTH == actualLength);
-        assertTrue(actualAllowNull);
-
-        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
+        validatorTester.verify(testParameterValue, PARAMETER_STRING_CANONCALIZE_TYPE_KEY, SECURITY_CONFIGURATION_TEST_LENGTH, true);
+        
         verify(mockSecConfig, times(1)).getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME);
         verify(mockRequest, times(1)).getParameter(testParameterName);
     }
@@ -538,20 +364,9 @@ public class SecurityWrapperRequestTest {
 
     @Test
     public void testGetParameterStringBooleanNullOnException() throws Exception{
-        ValidationException ve = new ValidationException("Thrown from test Scope", "Test Exception is intentional.");
+        ValidatorTestContainer validatorTester = new ValidatorTestContainer(mockValidator);
+        validatorTester.getValidInputThrows();
         
-        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
-        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
-
-        String context = anyString();
-        String input = inputCapture.capture();
-        String type = typeCapture.capture();
-        Integer length = lengthCapture.capture();
-        Boolean allowNull = allowNullCapture.capture();
-
-        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenThrow(ve);
         PowerMockito.when(mockSecConfig.getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME)).thenReturn(
                 SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -561,90 +376,106 @@ public class SecurityWrapperRequestTest {
         String rval = request.getParameter(testParameterName, false);
         assertNull(rval);
         
-        String actualInput = inputCapture.getValue();
-        String actualType = typeCapture.getValue();
-        int actualLength = lengthCapture.getValue().intValue();
-        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
-
-        assertEquals(testParameterValue, actualInput);
-        assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
-        assertTrue(SECURITY_CONFIGURATION_TEST_LENGTH == actualLength);
-        assertFalse(actualAllowNull);
-
-        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
+        validatorTester.verify(testParameterValue, PARAMETER_STRING_CANONCALIZE_TYPE_KEY, SECURITY_CONFIGURATION_TEST_LENGTH, false);
+    
         verify(mockSecConfig, times(1)).getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME);
         verify(mockRequest, times(1)).getParameter(testParameterName);
     }
     
     @Test
     public void testGetParameterStringBooleanIntNullOnException() throws Exception{
-        ValidationException ve = new ValidationException("Thrown from test Scope", "Test Exception is intentional.");
+        ValidatorTestContainer validatorTester = new ValidatorTestContainer(mockValidator);
+        validatorTester.getValidInputThrows();
         
-        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
-        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
-
-        String context = anyString();
-        String input = inputCapture.capture();
-        String type = typeCapture.capture();
-        Integer length = lengthCapture.capture();
-        Boolean allowNull = allowNullCapture.capture();
-
-        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenThrow(ve);
         PowerMockito.when(mockRequest.getParameter(testParameterName)).thenReturn(testParameterValue);
 
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
         String rval = request.getParameter(testParameterName, false, testMaximumLength);
         assertNull(rval);
         
-        String actualInput = inputCapture.getValue();
-        String actualType = typeCapture.getValue();
-        int actualLength = lengthCapture.getValue().intValue();
-        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
-
-        assertEquals(testParameterValue, actualInput);
-        assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
-        assertTrue(testMaximumLength == actualLength);
-        assertFalse(actualAllowNull);
-
-        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
+        validatorTester.verify(testParameterValue, PARAMETER_STRING_CANONCALIZE_TYPE_KEY, testMaximumLength, false);
         verify(mockRequest, times(1)).getParameter(testParameterName);
     }
     
     @Test
     public void testGetParameterStringBooleanIntStringNullOnException() throws Exception{
-        ValidationException ve = new ValidationException("Thrown from test Scope", "Test Exception is intentional.");
-        
-        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
-        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
+        ValidatorTestContainer validatorTester = new ValidatorTestContainer(mockValidator);
+        validatorTester.getValidInputThrows();
 
-        String context = anyString();
-        String input = inputCapture.capture();
-        String type = typeCapture.capture();
-        Integer length = lengthCapture.capture();
-        Boolean allowNull = allowNullCapture.capture();
-
-        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenThrow(ve);
         PowerMockito.when(mockRequest.getParameter(testParameterName)).thenReturn(testParameterValue);
 
         SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
         String rval = request.getParameter(testParameterName, false, testMaximumLength, testValidatorType);
         assertNull(rval);
-
-        String actualInput = inputCapture.getValue();
-        String actualType = typeCapture.getValue();
-        int actualLength = lengthCapture.getValue().intValue();
-        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
-
-        assertEquals(testParameterValue, actualInput);
-        assertEquals(testValidatorType, actualType);
-        assertTrue(testMaximumLength == actualLength);
-        assertFalse(actualAllowNull);
-
-        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
+        
+        validatorTester.verify(testParameterValue, testValidatorType, testMaximumLength, false);
+       
         verify(mockRequest, times(1)).getParameter(testParameterName);
+    }
+
+    /**
+     * Utility test class meant to encapsulate common interactions for preparing and
+     * verifying the Validator interactions common to multiple tests.
+     *
+     */
+    private class ValidatorTestContainer {
+        private ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
+        private ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
+        private ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
+        private ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
+        private Validator validator;
+        
+        
+        public ValidatorTestContainer(Validator validatorRef) {
+            this.validator = validatorRef;
+        }
+        public Answer<String> throwException() {
+            return new Answer<String>() {
+                @Override
+                public String answer(InvocationOnMock invocation) throws Throwable {
+                    throw new ValidationException("Thrown from test Scope", "Test Exception is intentional.");
+                }
+            };
+        }
+        
+        public Answer<String> returnResult(final String result) {
+            return new Answer<String>() {
+                @Override
+                public String answer(InvocationOnMock invocation) throws Throwable {
+                    return result;
+                }
+            };
+        }
+        public void getValidInputReturns(String response) throws Exception {
+            setupFor(returnResult(response));
+        }
+        
+        public void getValidInputThrows() throws Exception {
+            setupFor(throwException());
+        }
+        
+        public void setupFor(Answer<String> answer) throws Exception {
+            String context = anyString();
+            String input = inputCapture.capture();
+            String type = typeCapture.capture();
+            Integer length = lengthCapture.capture();
+            Boolean allowNull = allowNullCapture.capture();
+
+            PowerMockito.when(validator.getValidInput(context, input, type, length, allowNull)).thenAnswer(answer);
+        }
+        
+        public void verify(String input, String type, int maxLen, boolean allowNull) throws Exception {
+            String actualInput = inputCapture.getValue();
+            String actualType = typeCapture.getValue();
+            int actualLength = lengthCapture.getValue().intValue();
+            boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
+
+            assertEquals(input, actualInput);
+            assertEquals(type, actualType);
+            assertTrue(maxLen == actualLength);
+            assertEquals(allowNull, actualAllowNull);
+            
+            Mockito.verify(validator, times(1)).getValidInput(anyString(), ArgumentMatchers.eq(input), ArgumentMatchers.eq(type), ArgumentMatchers.eq(maxLen), ArgumentMatchers.eq(allowNull));
+        }
     }
 }

--- a/src/test/java/org/owasp/esapi/filters/SecurityWrapperRequestTest.java
+++ b/src/test/java/org/owasp/esapi/filters/SecurityWrapperRequestTest.java
@@ -15,6 +15,7 @@
 package org.owasp.esapi.filters;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -61,10 +62,7 @@ public class SecurityWrapperRequestTest {
 
     private static final String QUERY_STRING_CANONCALIZE_TYPE_KEY = "HTTPQueryString";
     private static final String PARAMETER_STRING_CANONCALIZE_TYPE_KEY = "HTTPParameterValue";
-    
-    private class GetValidInputCaptures {
-        
-    }
+  
 
     @Mock
     private HttpServletRequest mockRequest;
@@ -220,6 +218,130 @@ public class SecurityWrapperRequestTest {
         verify(mockRequest, times(1)).getParameter(parameterName);
     }
 
+    @Test
+    public void testGetParameterStringBoolean() throws Exception{
+        String originalParam = "aParameterValue";
+        String parameterName = "SomeParameterName";
+        String cannonicalParam="safeParameterValue";
+
+        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
+
+        String context = anyString();
+        String input = inputCapture.capture();
+        String type = typeCapture.capture();
+        Integer length = lengthCapture.capture();
+        Boolean allowNull = allowNullCapture.capture();
+
+        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
+                cannonicalParam);
+        PowerMockito.when(mockSecConfig.getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME)).thenReturn(
+                SECURITY_CONFIGURATION_TEST_LENGTH);
+
+        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+
+        SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
+        String rval = request.getParameter(parameterName, false);
+        assertEquals(cannonicalParam, rval);
+
+        String actualInput = inputCapture.getValue();
+        String actualType = typeCapture.getValue();
+        int actualLength = lengthCapture.getValue().intValue();
+        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
+
+        assertEquals(originalParam, actualInput);
+        assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
+        assertTrue(SECURITY_CONFIGURATION_TEST_LENGTH == actualLength);
+        assertFalse(actualAllowNull);
+
+        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
+        verify(mockSecConfig, times(1)).getIntProp(SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME);
+        verify(mockRequest, times(1)).getParameter(parameterName);
+    }
+    
+    @Test
+    public void testGetParameterStringBooleanInt() throws Exception{
+        String originalParam = "aParameterValue";
+        String parameterName = "SomeParameterName";
+        String cannonicalParam="safeParameterValue";
+
+        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
+
+        String context = anyString();
+        String input = inputCapture.capture();
+        String type = typeCapture.capture();
+        Integer length = lengthCapture.capture();
+        Boolean allowNull = allowNullCapture.capture();
+
+        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
+                cannonicalParam);
+        
+        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+
+        SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
+        String rval = request.getParameter(parameterName, false, 75);
+        assertEquals(cannonicalParam, rval);
+
+        String actualInput = inputCapture.getValue();
+        String actualType = typeCapture.getValue();
+        int actualLength = lengthCapture.getValue().intValue();
+        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
+
+        assertEquals(originalParam, actualInput);
+        assertEquals(PARAMETER_STRING_CANONCALIZE_TYPE_KEY, actualType);
+        assertTrue(75 == actualLength);
+        assertFalse(actualAllowNull);
+
+        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
+        verify(mockRequest, times(1)).getParameter(parameterName);
+    }
+    
+    @Test
+    public void testGetParameterStringBooleanIntString() throws Exception{
+        String originalParam = "aParameterValue";
+        String parameterName = "SomeParameterName";
+        String cannonicalParam="safeParameterValue";
+
+        ArgumentCaptor<String> inputCapture = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> typeCapture = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Integer> lengthCapture = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<Boolean> allowNullCapture = ArgumentCaptor.forClass(Boolean.class);
+
+        String context = anyString();
+        String input = inputCapture.capture();
+        String type = typeCapture.capture();
+        Integer length = lengthCapture.capture();
+        Boolean allowNull = allowNullCapture.capture();
+
+        PowerMockito.when(mockValidator.getValidInput(context, input, type, length, allowNull)).thenReturn(
+                cannonicalParam);
+        
+        PowerMockito.when(mockRequest.getParameter(parameterName)).thenReturn(originalParam);
+
+        SecurityWrapperRequest request = new SecurityWrapperRequest(mockRequest);
+        String rval = request.getParameter(parameterName, false, 75, "customType");
+        assertEquals(cannonicalParam, rval);
+
+        String actualInput = inputCapture.getValue();
+        String actualType = typeCapture.getValue();
+        int actualLength = lengthCapture.getValue().intValue();
+        boolean actualAllowNull = allowNullCapture.getValue().booleanValue();
+
+        assertEquals(originalParam, actualInput);
+        assertEquals("customType", actualType);
+        assertTrue(75 == actualLength);
+        assertFalse(actualAllowNull);
+
+        verify(mockValidator, times(1)).getValidInput(anyString(), anyString(), anyString(), anyInt(), anyBoolean());
+        verify(mockRequest, times(1)).getParameter(parameterName);
+    }
+
+    
     @Test
     public void testGetParameterStringNullEvalPassthrough() throws Exception{
         String originalParam = "aParameterValue";

--- a/src/test/java/org/owasp/esapi/reference/DefaultValidatorInputStringAPITest.java
+++ b/src/test/java/org/owasp/esapi/reference/DefaultValidatorInputStringAPITest.java
@@ -143,4 +143,35 @@ public class DefaultValidatorInputStringAPITest {
         Assert.assertEquals(1, errorList.size());
         Assert.assertEquals(validationEx, errorList.getError(contextStr));
     }
+    
+    
+    @Test
+    public void isValidInputNullAllowedPassthrough() throws Exception {
+        boolean isValid=  uit.isValidInput(contextStr, testName.getMethodName(), testValidatorType, testMaximumLength, true);
+        Assert.assertTrue(isValid);
+        
+        Mockito.verify(spyStringRule, Mockito.times(1)).addWhitelistPattern(TEST_PATTERN);
+        Mockito.verify(spyStringRule, Mockito.times(1)).setAllowNull(true);
+        Mockito.verify(spyStringRule, Mockito.times(0)).setAllowNull(false);
+        Mockito.verify(spyStringRule, Mockito.times(1)).setMaximumLength(testMaximumLength);
+        Mockito.verify(spyStringRule, Mockito.times(1)).getValid(contextStr, testName.getMethodName());
+    }
+    
+    @Test
+    public void isValidInputValidationExceptionReturnsFalse() throws Exception {
+        Mockito.doThrow(validationEx).when(spyStringRule).getValid(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
+        boolean result = uit.isValidInput(contextStr, testName.getMethodName(), testValidatorType, testMaximumLength, true);
+        Assert.assertFalse(result);
+    }
+    
+    @Test
+    public void isValidInputValidationExceptionErrorListReturnsFalse() throws Exception {
+        ValidationErrorList errorList = new ValidationErrorList();
+
+        Mockito.doThrow(validationEx).when(spyStringRule).getValid(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
+        boolean result = uit.isValidInput(contextStr, testName.getMethodName(), testValidatorType, testMaximumLength, true,errorList);
+        Assert.assertFalse(result);
+        Assert.assertEquals(1, errorList.size());
+        Assert.assertEquals(validationEx, errorList.getError(contextStr));
+    }
 }

--- a/src/test/java/org/owasp/esapi/reference/DefaultValidatorInputStringAPITest.java
+++ b/src/test/java/org/owasp/esapi/reference/DefaultValidatorInputStringAPITest.java
@@ -1,0 +1,146 @@
+package org.owasp.esapi.reference;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+import java.util.regex.Pattern;
+
+import org.hamcrest.core.Is;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.owasp.esapi.ESAPI;
+import org.owasp.esapi.Encoder;
+import org.owasp.esapi.SecurityConfiguration;
+import org.owasp.esapi.ValidationErrorList;
+import org.owasp.esapi.errors.ValidationException;
+import org.owasp.esapi.reference.validation.StringValidationRule;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * This class contains a subsection of tests of the DefaultValidator class 
+ * SPECIFIC TO THE INPUT 'STRING' VALIDATION API.
+ * 
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({DefaultValidator.class, ESAPI.class})
+public class DefaultValidatorInputStringAPITest {
+    private static final String ESAPY_SECURITY_CONFIGURATION_GETTER_METHOD_NAME = "securityConfiguration";
+    private static final Pattern TEST_PATTERN = Pattern.compile("");
+    @Rule
+    public ExpectedException exEx = ExpectedException.none();
+    @Rule
+    public TestName testName = new TestName();
+    @Mock
+    private SecurityConfiguration mockSecConfig;
+    @Mock
+    private Encoder mockEncoder;
+
+    private ValidationException validationEx;
+    private String contextStr;
+    private StringValidationRule spyStringRule;
+    private ValidationErrorList errors = new ValidationErrorList();
+    
+    private DefaultValidator uit;
+    private String testValidatorType;
+    private String validatorResultString;
+    private int testMaximumLength;
+    
+    @Before
+    public void setup() throws Exception {
+        //Is intrusion detection disabled?  A:  Yes, it is off.  
+        //This logic is confusing:  True, the value is False...
+        Mockito.when(mockSecConfig.getDisableIntrusionDetection()).thenReturn(true);
+        
+        contextStr = testName.getMethodName();
+        testValidatorType = testName.getMethodName() + "_validator_type";
+        validatorResultString = testName.getMethodName() + "_validator_result";
+        testMaximumLength = testName.getMethodName().length();
+        
+        validationEx = new ValidationException(contextStr, contextStr);
+        
+        mockEncoder = mock(Encoder.class);
+        uit = new DefaultValidator(mockEncoder);
+        
+        //Don't care how the StringValidationRule works, we just care that we forwarded the information as expected.
+        spyStringRule = new StringValidationRule(testValidatorType, mockEncoder); 
+        spyStringRule = spy(spyStringRule);
+        Mockito.doNothing().when(spyStringRule).addWhitelistPattern(ArgumentMatchers.<Pattern>any());
+        Mockito.doNothing().when(spyStringRule).setAllowNull(ArgumentMatchers.anyBoolean());
+        Mockito.doNothing().when(spyStringRule).setMaximumLength(ArgumentMatchers.anyInt());
+        Mockito.doReturn(validatorResultString).when(spyStringRule).getValid(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
+        whenNew(StringValidationRule.class).withArguments(eq(testValidatorType), eq(mockEncoder)).thenReturn(spyStringRule);
+        
+        errors = spy(errors);
+        whenNew(ValidationErrorList.class).withNoArguments().thenReturn(errors);
+        
+        
+        PowerMockito.mockStatic(ESAPI.class);
+        PowerMockito.when(ESAPI.class, ESAPY_SECURITY_CONFIGURATION_GETTER_METHOD_NAME).thenReturn(mockSecConfig);
+        
+        
+        Mockito.when(mockSecConfig.getValidationPattern(testValidatorType)).thenReturn(TEST_PATTERN);
+        
+    }
+    
+    @Test
+    public void getValidInputNullAllowedPassthrough() throws Exception {
+        String safeValue =  uit.getValidInput(contextStr, testName.getMethodName(), testValidatorType, testMaximumLength, true);
+        Assert.assertEquals(validatorResultString, safeValue);
+        Mockito.verify(spyStringRule, Mockito.times(1)).addWhitelistPattern(TEST_PATTERN);
+        Mockito.verify(spyStringRule, Mockito.times(1)).setAllowNull(true);
+        Mockito.verify(spyStringRule, Mockito.times(0)).setAllowNull(false);
+        Mockito.verify(spyStringRule, Mockito.times(1)).setMaximumLength(testMaximumLength);
+        Mockito.verify(spyStringRule, Mockito.times(1)).getValid(contextStr, testName.getMethodName());
+    }
+    
+    @Test
+    public void getValidInputNullNotAllowedPassthrough() throws Exception {
+        String safeValue =  uit.getValidInput(contextStr, testName.getMethodName(), testValidatorType, testMaximumLength, false);
+        Assert.assertEquals(validatorResultString, safeValue);
+        Mockito.verify(spyStringRule, Mockito.times(1)).addWhitelistPattern(TEST_PATTERN);
+        Mockito.verify(spyStringRule, Mockito.times(0)).setAllowNull(true);
+        Mockito.verify(spyStringRule, Mockito.times(1)).setAllowNull(false);
+        Mockito.verify(spyStringRule, Mockito.times(1)).setMaximumLength(testMaximumLength);
+        Mockito.verify(spyStringRule, Mockito.times(1)).getValid(contextStr, testName.getMethodName());
+    }
+    
+    @Test
+    public void getValidInputNullPatternThrows() throws Exception {
+        exEx.expect(IllegalArgumentException.class);
+        exEx.expectMessage(testValidatorType + "] was not set via the ESAPI validation configuration");
+        Mockito.when(mockSecConfig.getValidationPattern(testValidatorType)).thenReturn(null);
+    
+        uit.getValidInput(contextStr, testName.getMethodName(), testValidatorType, testMaximumLength, true);
+    }
+    
+    @Test
+    public void getValidInputValidationExceptionPropagates() throws Exception {
+        exEx.expect(Is.is(validationEx));
+
+        Mockito.doThrow(validationEx).when(spyStringRule).getValid(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
+        uit.getValidInput(contextStr, testName.getMethodName(), testValidatorType, testMaximumLength, true);
+    }
+    
+    @Test
+    public void getValidInputValidationExceptionErrorList() throws Exception {
+        ValidationErrorList errorList = new ValidationErrorList();
+
+        Mockito.doThrow(validationEx).when(spyStringRule).getValid(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
+       String result = uit.getValidInput(contextStr, testName.getMethodName(), testValidatorType, testMaximumLength, true,errorList);
+        Assert.assertTrue(result.isEmpty());
+        Assert.assertEquals(1, errorList.size());
+        Assert.assertEquals(validationEx, errorList.getError(contextStr));
+    }
+}

--- a/src/test/java/org/owasp/esapi/reference/DefaultValidatorInputStringAPITest.java
+++ b/src/test/java/org/owasp/esapi/reference/DefaultValidatorInputStringAPITest.java
@@ -1,14 +1,22 @@
 package org.owasp.esapi.reference;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 import java.util.regex.Pattern;
 
 import org.hamcrest.core.Is;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -17,7 +25,6 @@ import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.Encoder;
 import org.owasp.esapi.SecurityConfiguration;
@@ -61,7 +68,7 @@ public class DefaultValidatorInputStringAPITest {
     public void setup() throws Exception {
         //Is intrusion detection disabled?  A:  Yes, it is off.  
         //This logic is confusing:  True, the value is False...
-        Mockito.when(mockSecConfig.getDisableIntrusionDetection()).thenReturn(true);
+        when(mockSecConfig.getDisableIntrusionDetection()).thenReturn(true);
         
         contextStr = testName.getMethodName();
         testValidatorType = testName.getMethodName() + "_validator_type";
@@ -76,10 +83,10 @@ public class DefaultValidatorInputStringAPITest {
         //Don't care how the StringValidationRule works, we just care that we forwarded the information as expected.
         spyStringRule = new StringValidationRule(testValidatorType, mockEncoder); 
         spyStringRule = spy(spyStringRule);
-        Mockito.doNothing().when(spyStringRule).addWhitelistPattern(ArgumentMatchers.<Pattern>any());
-        Mockito.doNothing().when(spyStringRule).setAllowNull(ArgumentMatchers.anyBoolean());
-        Mockito.doNothing().when(spyStringRule).setMaximumLength(ArgumentMatchers.anyInt());
-        Mockito.doReturn(validatorResultString).when(spyStringRule).getValid(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
+        doNothing().when(spyStringRule).addWhitelistPattern(ArgumentMatchers.<Pattern>any());
+        doNothing().when(spyStringRule).setAllowNull(ArgumentMatchers.anyBoolean());
+        doNothing().when(spyStringRule).setMaximumLength(ArgumentMatchers.anyInt());
+        doReturn(validatorResultString).when(spyStringRule).getValid(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
         whenNew(StringValidationRule.class).withArguments(eq(testValidatorType), eq(mockEncoder)).thenReturn(spyStringRule);
         
         errors = spy(errors);
@@ -90,37 +97,37 @@ public class DefaultValidatorInputStringAPITest {
         PowerMockito.when(ESAPI.class, ESAPY_SECURITY_CONFIGURATION_GETTER_METHOD_NAME).thenReturn(mockSecConfig);
         
         
-        Mockito.when(mockSecConfig.getValidationPattern(testValidatorType)).thenReturn(TEST_PATTERN);
+        when(mockSecConfig.getValidationPattern(testValidatorType)).thenReturn(TEST_PATTERN);
         
     }
     
     @Test
     public void getValidInputNullAllowedPassthrough() throws Exception {
         String safeValue =  uit.getValidInput(contextStr, testName.getMethodName(), testValidatorType, testMaximumLength, true);
-        Assert.assertEquals(validatorResultString, safeValue);
-        Mockito.verify(spyStringRule, Mockito.times(1)).addWhitelistPattern(TEST_PATTERN);
-        Mockito.verify(spyStringRule, Mockito.times(1)).setAllowNull(true);
-        Mockito.verify(spyStringRule, Mockito.times(0)).setAllowNull(false);
-        Mockito.verify(spyStringRule, Mockito.times(1)).setMaximumLength(testMaximumLength);
-        Mockito.verify(spyStringRule, Mockito.times(1)).getValid(contextStr, testName.getMethodName());
+        assertEquals(validatorResultString, safeValue);
+        verify(spyStringRule, times(1)).addWhitelistPattern(TEST_PATTERN);
+        verify(spyStringRule, times(1)).setAllowNull(true);
+        verify(spyStringRule, times(0)).setAllowNull(false);
+        verify(spyStringRule, times(1)).setMaximumLength(testMaximumLength);
+        verify(spyStringRule, times(1)).getValid(contextStr, testName.getMethodName());
     }
     
     @Test
     public void getValidInputNullNotAllowedPassthrough() throws Exception {
         String safeValue =  uit.getValidInput(contextStr, testName.getMethodName(), testValidatorType, testMaximumLength, false);
-        Assert.assertEquals(validatorResultString, safeValue);
-        Mockito.verify(spyStringRule, Mockito.times(1)).addWhitelistPattern(TEST_PATTERN);
-        Mockito.verify(spyStringRule, Mockito.times(0)).setAllowNull(true);
-        Mockito.verify(spyStringRule, Mockito.times(1)).setAllowNull(false);
-        Mockito.verify(spyStringRule, Mockito.times(1)).setMaximumLength(testMaximumLength);
-        Mockito.verify(spyStringRule, Mockito.times(1)).getValid(contextStr, testName.getMethodName());
+        assertEquals(validatorResultString, safeValue);
+        verify(spyStringRule, times(1)).addWhitelistPattern(TEST_PATTERN);
+        verify(spyStringRule, times(0)).setAllowNull(true);
+        verify(spyStringRule, times(1)).setAllowNull(false);
+        verify(spyStringRule, times(1)).setMaximumLength(testMaximumLength);
+        verify(spyStringRule, times(1)).getValid(contextStr, testName.getMethodName());
     }
     
     @Test
     public void getValidInputNullPatternThrows() throws Exception {
         exEx.expect(IllegalArgumentException.class);
         exEx.expectMessage(testValidatorType + "] was not set via the ESAPI validation configuration");
-        Mockito.when(mockSecConfig.getValidationPattern(testValidatorType)).thenReturn(null);
+        when(mockSecConfig.getValidationPattern(testValidatorType)).thenReturn(null);
     
         uit.getValidInput(contextStr, testName.getMethodName(), testValidatorType, testMaximumLength, true);
     }
@@ -129,7 +136,7 @@ public class DefaultValidatorInputStringAPITest {
     public void getValidInputValidationExceptionPropagates() throws Exception {
         exEx.expect(Is.is(validationEx));
 
-        Mockito.doThrow(validationEx).when(spyStringRule).getValid(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
+        doThrow(validationEx).when(spyStringRule).getValid(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
         uit.getValidInput(contextStr, testName.getMethodName(), testValidatorType, testMaximumLength, true);
     }
     
@@ -137,41 +144,41 @@ public class DefaultValidatorInputStringAPITest {
     public void getValidInputValidationExceptionErrorList() throws Exception {
         ValidationErrorList errorList = new ValidationErrorList();
 
-        Mockito.doThrow(validationEx).when(spyStringRule).getValid(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
+        doThrow(validationEx).when(spyStringRule).getValid(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
        String result = uit.getValidInput(contextStr, testName.getMethodName(), testValidatorType, testMaximumLength, true,errorList);
-        Assert.assertTrue(result.isEmpty());
-        Assert.assertEquals(1, errorList.size());
-        Assert.assertEquals(validationEx, errorList.getError(contextStr));
+        assertTrue(result.isEmpty());
+        assertEquals(1, errorList.size());
+        assertEquals(validationEx, errorList.getError(contextStr));
     }
     
     
     @Test
     public void isValidInputNullAllowedPassthrough() throws Exception {
         boolean isValid=  uit.isValidInput(contextStr, testName.getMethodName(), testValidatorType, testMaximumLength, true);
-        Assert.assertTrue(isValid);
+        assertTrue(isValid);
         
-        Mockito.verify(spyStringRule, Mockito.times(1)).addWhitelistPattern(TEST_PATTERN);
-        Mockito.verify(spyStringRule, Mockito.times(1)).setAllowNull(true);
-        Mockito.verify(spyStringRule, Mockito.times(0)).setAllowNull(false);
-        Mockito.verify(spyStringRule, Mockito.times(1)).setMaximumLength(testMaximumLength);
-        Mockito.verify(spyStringRule, Mockito.times(1)).getValid(contextStr, testName.getMethodName());
+        verify(spyStringRule, times(1)).addWhitelistPattern(TEST_PATTERN);
+        verify(spyStringRule, times(1)).setAllowNull(true);
+        verify(spyStringRule, times(0)).setAllowNull(false);
+        verify(spyStringRule, times(1)).setMaximumLength(testMaximumLength);
+        verify(spyStringRule, times(1)).getValid(contextStr, testName.getMethodName());
     }
     
     @Test
     public void isValidInputValidationExceptionReturnsFalse() throws Exception {
-        Mockito.doThrow(validationEx).when(spyStringRule).getValid(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
+        doThrow(validationEx).when(spyStringRule).getValid(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
         boolean result = uit.isValidInput(contextStr, testName.getMethodName(), testValidatorType, testMaximumLength, true);
-        Assert.assertFalse(result);
+        assertFalse(result);
     }
     
     @Test
     public void isValidInputValidationExceptionErrorListReturnsFalse() throws Exception {
         ValidationErrorList errorList = new ValidationErrorList();
 
-        Mockito.doThrow(validationEx).when(spyStringRule).getValid(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
+        doThrow(validationEx).when(spyStringRule).getValid(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
         boolean result = uit.isValidInput(contextStr, testName.getMethodName(), testValidatorType, testMaximumLength, true,errorList);
-        Assert.assertFalse(result);
-        Assert.assertEquals(1, errorList.size());
-        Assert.assertEquals(validationEx, errorList.getError(contextStr));
+        assertFalse(result);
+        assertEquals(1, errorList.size());
+        assertEquals(validationEx, errorList.getError(contextStr));
     }
 }


### PR DESCRIPTION
Issue 188 is already functionally complete in the current baseline.  These changes are only test updates for each of the elements in the current workflow to show that each propagates information as desired.

Summary of changes:
Tests added to the SecurityWrapperRequestTest to show that the arguments provided to the wrapper are forwaded to the configured Validator instance.

ESAPIContractAPITest already exists and shows that the ESAPI lookup does return the expected configuration instance for the Validator lookup.

The tests DefaultValidatorInputStringAPITest were added to assert the passthrough behavior of the isValidInput and getValidInput methods of the DefaultValidator.  Note that the -canonicalize- variable to the getValidInput API was not tested, as it is never used and only exists in the scope of the methods which accept it.

StringValidationRuleTest already coveres a good portion of the functional intent of the StringValidationRule implementation.