### PR TITLE
#476 DefaultValidator.getValidInput uses canonicalize method argument

### DIFF
--- a/src/main/java/org/owasp/esapi/reference/DefaultValidator.java
+++ b/src/main/java/org/owasp/esapi/reference/DefaultValidator.java
@@ -216,6 +216,7 @@ public class DefaultValidator implements org.owasp.esapi.Validator {
 		}
 		rvr.setMaximumLength(maxLength);
 		rvr.setAllowNull(allowNull);
+		rvr.setCanonicalize(canonicalize);
 		return rvr.getValid(context, input);
 	}
 

--- a/src/main/java/org/owasp/esapi/reference/validation/StringValidationRule.java
+++ b/src/main/java/org/owasp/esapi/reference/validation/StringValidationRule.java
@@ -44,6 +44,7 @@ public class StringValidationRule extends BaseValidationRule {
 	protected List<Pattern> blacklistPatterns = new ArrayList<Pattern>();
 	protected int minLength = 0;
 	protected int maxLength = Integer.MAX_VALUE;
+	private boolean canonicalizeInput = true;
 
 	public StringValidationRule( String typeName ) {
 		super( typeName );
@@ -113,6 +114,10 @@ public class StringValidationRule extends BaseValidationRule {
 
 	public void setMaximumLength( int length ) {
 		maxLength = length;
+	}
+
+	public void setCanonicalize(boolean canonicalize) {
+	    this.canonicalizeInput = canonicalize;
 	}
 
 	/**
@@ -264,7 +269,7 @@ public class StringValidationRule extends BaseValidationRule {
 		checkLength(context, input);
 		
 		// canonicalize
-		data = encoder.canonicalize( input );
+		data = canonicalizeInput ? encoder.canonicalize( input ) : input;
 
 		// check whitelist patterns
 		checkWhitelist(context, input);
@@ -283,6 +288,7 @@ public class StringValidationRule extends BaseValidationRule {
 		public String sanitize( String context, String input ) {
 			return whitelist( input, EncoderConstants.CHAR_ALPHANUMERICS );
 		}
+
 
 }
 

--- a/src/main/java/org/owasp/esapi/reference/validation/StringValidationRule.java
+++ b/src/main/java/org/owasp/esapi/reference/validation/StringValidationRule.java
@@ -20,8 +20,10 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.Encoder;
 import org.owasp.esapi.EncoderConstants;
+import org.owasp.esapi.Logger;
 import org.owasp.esapi.StringUtilities;
 import org.owasp.esapi.errors.ValidationException;
 import org.owasp.esapi.util.NullSafe;
@@ -39,7 +41,7 @@ import org.owasp.esapi.util.NullSafe;
  * http://en.wikipedia.org/wiki/Whitelist
  */
 public class StringValidationRule extends BaseValidationRule {
-
+    private static final Logger LOGGER = ESAPI.getLogger(StringValidationRule.class);
 	protected List<Pattern> whitelistPatterns = new ArrayList<Pattern>();
 	protected List<Pattern> blacklistPatterns = new ArrayList<Pattern>();
 	protected int minLength = 0;
@@ -267,9 +269,15 @@ public class StringValidationRule extends BaseValidationRule {
 
 		// check length
 		checkLength(context, input);
-		
+
 		// canonicalize
-		data = canonicalizeInput ? encoder.canonicalize( input ) : input;
+		if (canonicalizeInput) {
+		    data = encoder.canonicalize(input);
+		} else {
+		    String message = String.format("Input validaiton excludes canonicalization.  Context: %s   Input: %s", context, input);
+		    LOGGER.warning(Logger.SECURITY_AUDIT, message);
+            data = input;
+		}
 
 		// check whitelist patterns
 		checkWhitelist(context, input);

--- a/src/test/java/org/owasp/esapi/reference/validation/StringValidationRuleTest.java
+++ b/src/test/java/org/owasp/esapi/reference/validation/StringValidationRuleTest.java
@@ -3,6 +3,9 @@ package org.owasp.esapi.reference.validation;
 import junit.framework.Assert;
 
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.owasp.esapi.Encoder;
 import org.owasp.esapi.ValidationErrorList;
 import org.owasp.esapi.errors.ValidationException;
 
@@ -153,6 +156,25 @@ public class StringValidationRuleTest {
 		validationRule.setAllowNull(true);
 		Assert.assertTrue(validationRule.isAllowNull());
 		Assert.assertTrue(validationRule.isValid("", null));
+	}
+	
+	@Test
+	public void testSetCanonicalize() throws ValidationException {
+	    String context = "test-scope";
+	    String inputString = "SomeInputValue";
+	    String encoderReturn = "MockReturnValue";
+	    Encoder mockEncoder = Mockito.mock(Encoder.class);
+	    Mockito.when(mockEncoder.canonicalize(inputString)).thenReturn(encoderReturn);
+	    StringValidationRule testRule = new StringValidationRule(context, mockEncoder);
+	    String valid = testRule.getValid(context, inputString);
+	    Assert.assertEquals(encoderReturn, valid);
+	    Mockito.verify(mockEncoder, Mockito.times(1)).canonicalize(inputString);
+	    Mockito.reset(mockEncoder);
+	    
+	    testRule.setCanonicalize(false);
+        valid = testRule.getValid(context, inputString);
+        Assert.assertEquals(inputString, valid);
+        Mockito.verify(mockEncoder, Mockito.times(0)).canonicalize(inputString);
 	}
 	
 }


### PR DESCRIPTION
Implementation and test updates consistent with the recommended approach.  StringValidationRule behavior for canonicalization is now configurable & DefaultValidator uses that configuration when evaluating a valid String input.

Tests updated to match expectations.