### PR TITLE
Close issue #512 by updating to 1.9.4 of Commons Beans Util.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,8 +171,8 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <!-- We need to use 1.9.2 (or later) here to address CVE-2014-0114. -->
-            <version>1.9.3</version>
+            <!-- We need to use 1.9.4 (or later) here to address CVE-2014-0114 and CVE-2019-10086. -->
+            <version>1.9.4</version>
             <!-- NOTE: commons-beanutils uses commons-collections 3.2.2. We use
                  commons-collections 4.2. Package names are different so this shouldn't
                  cause any problems as long as 3.x doesn't have any CVEs. May have to


### PR DESCRIPTION
Close issue #512 and any Java deserialization vulnerabilities that might present themselves as a result. (Note that regarding the BeanUtils commit, the fix was in org.apache.commons.beanutils2.PropertyUtilsBean. Based on a cursory examination, the ESAPI team does not believe that this vulnerability reported by Snyk was exploitable given that manner that it is used within ESAPI, or if it is, it is not externally exploitable based on the default access control rules that are provided with ESAPI. However, to be prudent and patching it seems to be the wise course if for no other reason, it will make Snyk shut up! :)