### PR TITLE
Issue 494 CSSCodec RGB Triplets

### DIFF
--- a/src/main/java/org/owasp/esapi/codecs/CSSCodec.java
+++ b/src/main/java/org/owasp/esapi/codecs/CSSCodec.java
@@ -15,6 +15,10 @@
  */
 package org.owasp.esapi.codecs;
 
+import java.util.regex.Pattern;
+
+import org.owasp.esapi.codecs.ref.EncodingPatternPreservation;
+
 /**
  * Implementation of the Codec interface for backslash encoding used in CSS.
  * 
@@ -26,8 +30,21 @@ package org.owasp.esapi.codecs;
 public class CSSCodec extends AbstractCharacterCodec
 {
 	private static final Character REPLACEMENT = '\ufffd';
-
-
+	//rgb (###,###,###) OR rgb(###%,###%,###%)
+	//([rR][gG][bB])\s*\(\s*\d{1,3}\s*(\%)?\s*,\s*\d{1,3}\s*(\%)?\s*,\s*\d{1,3}\s*(\%)?\s*\)
+	private static final String RGB_TRPLT = "([rR][gG][bB])\\s*\\(\\s*\\d{1,3}\\s*(\\%)?\\s*,\\s*\\d{1,3}\\s*(\\%)?\\s*,\\s*\\d{1,3}\\s*(\\%)?\\s*\\)";
+	private static final Pattern RGB_TRPLT_PATTERN = Pattern.compile(RGB_TRPLT); 
+	
+	@Override
+	public String encode(char[] immune, String input) {
+		 EncodingPatternPreservation tripletCheck = new EncodingPatternPreservation(RGB_TRPLT_PATTERN);
+		 
+		 String inputChk = tripletCheck.captureAndReplaceMatches(input);
+		 
+		 String result = super.encode(immune, inputChk);
+		 
+		 return tripletCheck.restoreOriginalContent(result);
+	}
     /**
 	 * {@inheritDoc}
 	 *
@@ -63,6 +80,7 @@ public class CSSCodec extends AbstractCharacterCodec
 	{
 		input.mark();
 		Character first = input.next();
+		System.out.println("First: " + first);
 		if (first == null || first != '\\')
 		{
 			input.reset();
@@ -70,6 +88,7 @@ public class CSSCodec extends AbstractCharacterCodec
 		}
 
 		Character second = input.next();
+		System.out.println("Second: " );
 		if (second == null) {
 			input.reset();
 			return null;

--- a/src/main/java/org/owasp/esapi/codecs/CSSCodec.java
+++ b/src/main/java/org/owasp/esapi/codecs/CSSCodec.java
@@ -80,7 +80,6 @@ public class CSSCodec extends AbstractCharacterCodec
 	{
 		input.mark();
 		Character first = input.next();
-		System.out.println("First: " + first);
 		if (first == null || first != '\\')
 		{
 			input.reset();
@@ -88,7 +87,6 @@ public class CSSCodec extends AbstractCharacterCodec
 		}
 
 		Character second = input.next();
-		System.out.println("Second: " );
 		if (second == null) {
 			input.reset();
 			return null;

--- a/src/main/java/org/owasp/esapi/codecs/ref/EncodingPatternPreservation.java
+++ b/src/main/java/org/owasp/esapi/codecs/ref/EncodingPatternPreservation.java
@@ -58,12 +58,11 @@ public class EncodingPatternPreservation {
 		Matcher matcher = noEncodeContent.matcher(input);
 
 		while (matcher.find()) {
-			int groups = matcher.groupCount();
-			for (int x = 0; x < groups; x++) {
-				String replaceContent = matcher.group(x);
+			String replaceContent = matcher.group(0);
+			if (replaceContent != null) {
 				replacedContentList.add(replaceContent);
 				inputCpy = inputCpy.replaceFirst(noEncodeContent.pattern(), replacementMarker);
-			}
+			}			
 		}
 
 		return inputCpy;

--- a/src/main/java/org/owasp/esapi/codecs/ref/EncodingPatternPreservation.java
+++ b/src/main/java/org/owasp/esapi/codecs/ref/EncodingPatternPreservation.java
@@ -1,0 +1,112 @@
+package org.owasp.esapi.codecs.ref;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * String mutation utility which can be used to replace all occurrences of a
+ * defined regular expression with a marker string, and also restore the
+ * original string content.
+ *
+ */
+public class EncodingPatternPreservation {
+	/** Default replacement marker. */
+	private static final String REPLACEMENT_MARKER = EncodingPatternPreservation.class.getSimpleName();
+	/** Pattern that is used to identify which content should be replaced. */
+	private final Pattern noEncodeContent;
+	/** The Marker used to replace found Pattern references. */
+	private String replacementMarker = REPLACEMENT_MARKER;
+
+	/**
+	 * The ordered-list of elements that were replaced in the last call to
+	 * {@link #captureAndReplaceMatches(String)}, and that will be used to replace
+	 * the {@link #replacementMarker} on the next call to
+	 * {@link #restoreOriginalContent(String)}
+	 */
+	private final List<String> replacedContentList = new ArrayList<>();
+
+	/**
+	 * Constructor.
+	 * 
+	 * @param pattern Pattern identifying content being replaced.
+	 */
+	public EncodingPatternPreservation(Pattern pattern) {
+		noEncodeContent = pattern;
+	}
+
+	/**
+	 * Replaces each matching instance of this instance's Pattern with an
+	 * identifiable replacement marker. <br>
+	 * 
+	 * <br>
+	 * After the encoding process is complete, use
+	 * {@link #restoreOriginalContent(String)} to re-insert the original data.
+	 * 
+	 * @param input String to adjust
+	 * @return The adjusted String
+	 */
+	public String captureAndReplaceMatches(String input) {
+		if (!replacedContentList.isEmpty()) {
+			// This may seem odd, but this will prevent programmer error that would result
+			// in being unable to restore a previously tokenized String.
+			String message = "Previously captured state is still present in instance. Call PatternContentPreservation.reset() to clear out preserved state and to reuse the reference.";
+			throw new IllegalStateException(message);
+		}
+		String inputCpy = input;
+		Matcher matcher = noEncodeContent.matcher(input);
+
+		while (matcher.find()) {
+			int groups = matcher.groupCount();
+			for (int x = 0; x < groups; x++) {
+				String replaceContent = matcher.group(x);
+				replacedContentList.add(replaceContent);
+				inputCpy = inputCpy.replaceFirst(noEncodeContent.pattern(), replacementMarker);
+			}
+		}
+
+		return inputCpy;
+	}
+
+	/**
+	 * Replaces each instance of the {@link #replacementMarker} with the original
+	 * content, as captured by {@link #captureAndReplaceMatches(String)}
+	 * 
+	 * @param input String to restore.
+	 * @return String reference with all values replaced.
+	 */
+	public String restoreOriginalContent(String input) {
+		String result = input;
+		while (replacedContentList.size() > 0) {
+			String origValue = replacedContentList.remove(0);
+			result = result.replaceFirst(replacementMarker, origValue);
+		}
+
+		return result;
+
+	}
+
+	/**
+	 * Allows the marker used as a replacement to be altered.
+	 * 
+	 * @param marker String replacment to use for regex matches.
+	 */
+	public void setReplacementMarker(String marker) {
+		if (!replacedContentList.isEmpty()) {
+			// This may seem odd, but this will prevent programmer error that would result
+			// in being unable to restore a previously tokenized String.
+			String message = "Previously captured state is still present in instance. Call PatternContentPreservation.reset() to clear out preserved state and to alter the marker.";
+			throw new IllegalStateException(message);
+		}
+		this.replacementMarker = marker;
+	}
+
+	/**
+	 * Clears any stored replacement values out of the instance.
+	 */
+	public void reset() {
+		replacedContentList.clear();
+	}
+
+}

--- a/src/test/java/org/owasp/esapi/codecs/CSSCodecTest.java
+++ b/src/test/java/org/owasp/esapi/codecs/CSSCodecTest.java
@@ -1,0 +1,33 @@
+package org.owasp.esapi.codecs;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class CSSCodecTest {
+	private static final char[] IMMUNE_STUB = new char[0];
+	/** Unit In Test*/
+	private CSSCodec uit = new CSSCodec();
+	
+	@Test
+    public void testCSSTripletLeadString() {
+    	assertEquals("rgb(255,255,255)\\21 ", uit.encode(IMMUNE_STUB, "rgb(255,255,255)!"));
+    	assertEquals("rgb(25%,25%,25%)\\21 ", uit.encode(IMMUNE_STUB, "rgb(25%,25%,25%)!"));
+    }
+	@Test
+    public void testCSSTripletTailString() {
+    	assertEquals("\\24 field\\3d rgb(255,255,255)\\21 ", uit.encode(IMMUNE_STUB, "$field=rgb(255,255,255)!"));
+    	assertEquals("\\24 field\\3d rgb(25%,25%,25%)\\21 ", uit.encode(IMMUNE_STUB, "$field=rgb(25%,25%,25%)!"));
+    }
+	@Test
+    public void testCSSTripletStringPart() {
+    	assertEquals("\\24 field\\3d rgb(255,255,255)\\21 ", uit.encode(IMMUNE_STUB, "$field=rgb(255,255,255)!"));
+    	assertEquals("\\24 field\\3d rgb(25%,25%,25%)\\21 ", uit.encode(IMMUNE_STUB, "$field=rgb(25%,25%,25%)!"));
+    }
+	@Test
+    public void testCSSTripletStringMultiPart() {
+    	assertEquals("\\24 field\\3d rgb(255,255,255)\\21 \\20 \\24 field\\3d rgb(255,255,255)\\21 ", uit.encode(IMMUNE_STUB, "$field=rgb(255,255,255)! $field=rgb(255,255,255)!"));
+    	assertEquals("\\24 field\\3d rgb(25%,25%,25%)\\21 \\20 \\24 field\\3d rgb(25%,25%,25%)\\21 ", uit.encode(IMMUNE_STUB, "$field=rgb(25%,25%,25%)! $field=rgb(25%,25%,25%)!"));
+    	assertEquals("\\24 field\\3d rgb(255,255,255)\\21 \\20 \\24 field\\3d rgb(25%,25%,25%)\\21 ", uit.encode(IMMUNE_STUB, "$field=rgb(255,255,255)! $field=rgb(25%,25%,25%)!"));
+    }
+}

--- a/src/test/java/org/owasp/esapi/codecs/ref/EncodingPatternPreservationTest.java
+++ b/src/test/java/org/owasp/esapi/codecs/ref/EncodingPatternPreservationTest.java
@@ -22,6 +22,19 @@ public class EncodingPatternPreservationTest {
 	}
 	
 	@Test
+	public void testReplaceMultipleAndRestore() {
+		Pattern numberRegex = Pattern.compile("(ABC)");
+		EncodingPatternPreservation epp = new EncodingPatternPreservation(numberRegex);
+		String origStr = "12 ABC 34 ABC 56 G 7 ABC8";
+		String replacedStr = epp.captureAndReplaceMatches(origStr);
+		
+		assertEquals("12 EncodingPatternPreservation 34 EncodingPatternPreservation 56 G 7 EncodingPatternPreservation8", replacedStr);
+		
+		String restored = epp.restoreOriginalContent(replacedStr);
+		assertEquals(origStr, restored);
+	}
+	
+	@Test
 	public void testSetMarker() {
 		Pattern numberRegex = Pattern.compile("(ABC)");
 		EncodingPatternPreservation epp = new EncodingPatternPreservation(numberRegex);

--- a/src/test/java/org/owasp/esapi/codecs/ref/EncodingPatternPreservationTest.java
+++ b/src/test/java/org/owasp/esapi/codecs/ref/EncodingPatternPreservationTest.java
@@ -1,0 +1,66 @@
+package org.owasp.esapi.codecs.ref;
+
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class EncodingPatternPreservationTest {
+	
+	@Test
+	public void testReplaceAndRestore() {
+		Pattern numberRegex = Pattern.compile("(ABC)");
+		EncodingPatternPreservation epp = new EncodingPatternPreservation(numberRegex);
+		String origStr = "12 ABC 34 DEF 56 G 7";
+		String replacedStr = epp.captureAndReplaceMatches(origStr);
+		
+		assertEquals("12 EncodingPatternPreservation 34 DEF 56 G 7", replacedStr);
+		
+		String restored = epp.restoreOriginalContent(replacedStr);
+		assertEquals(origStr, restored);
+	}
+	
+	@Test
+	public void testSetMarker() {
+		Pattern numberRegex = Pattern.compile("(ABC)");
+		EncodingPatternPreservation epp = new EncodingPatternPreservation(numberRegex);
+		epp.setReplacementMarker(EncodingPatternPreservationTest.class.getSimpleName());
+		
+		String origStr = "12 ABC 34 DEF 56 G 7";
+		String replacedStr = epp.captureAndReplaceMatches(origStr);
+		
+		assertEquals("12 EncodingPatternPreservationTest 34 DEF 56 G 7", replacedStr);
+		
+		String restored = epp.restoreOriginalContent(replacedStr);
+		assertEquals(origStr, restored);
+	}
+	
+	@Test (expected = IllegalStateException.class)
+	public void testSetMarkerExceptionNoReset() {
+		Pattern numberRegex = Pattern.compile("(ABC)");
+		EncodingPatternPreservation epp = new EncodingPatternPreservation(numberRegex);
+		String origStr = "12 ABC 34 DEF 56 G 7";
+		epp.captureAndReplaceMatches(origStr);
+		//This allows the + case to be illustrated
+		epp.reset();
+		
+		//And the exception case.
+		epp.captureAndReplaceMatches(origStr);
+		epp.setReplacementMarker(EncodingPatternPreservationTest.class.getSimpleName());
+	}
+	
+	@Test (expected = IllegalStateException.class)
+	public void testReplaceExceptionNoReset() {
+		Pattern numberRegex = Pattern.compile("(ABC)");
+		EncodingPatternPreservation epp = new EncodingPatternPreservation(numberRegex);
+		String origStr = "12 ABC 34 DEF 56 G 7";
+		epp.captureAndReplaceMatches(origStr);
+		//This allows the + case to be illustrated
+		epp.reset();
+		
+		//And the exception case.
+		epp.captureAndReplaceMatches(origStr);
+		epp.captureAndReplaceMatches(origStr);
+	}
+}

--- a/src/test/java/org/owasp/esapi/reference/EncoderTest.java
+++ b/src/test/java/org/owasp/esapi/reference/EncoderTest.java
@@ -15,19 +15,23 @@
  */
 package org.owasp.esapi.reference;
 
-import java.io.ByteArrayOutputStream;
+import static org.junit.Assert.assertEquals;
+
 import java.io.IOException;
-import java.io.ObjectOutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import org.junit.Ignore;
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.Encoder;
 import org.owasp.esapi.EncoderConstants;
-import org.owasp.esapi.codecs.Base64;
+import org.owasp.esapi.codecs.CSSCodec;
 import org.owasp.esapi.codecs.Codec;
 import org.owasp.esapi.codecs.HTMLEntityCodec;
 import org.owasp.esapi.codecs.MySQLCodec;
@@ -376,7 +380,7 @@ public class EncoderTest extends TestCase {
     /**
      *
      */
-    public void testEncodeForCSS() {
+    public void testencodeForCSS() {
         System.out.println("encodeForCSS");
         Encoder instance = ESAPI.encoder();
         assertEquals(null, instance.encodeForCSS(null));
@@ -385,11 +389,32 @@ public class EncoderTest extends TestCase {
         assertEquals("#f00", instance.encodeForCSS("#f00"));
         assertEquals("#123456", instance.encodeForCSS("#123456"));
         assertEquals("#abcdef", instance.encodeForCSS("#abcdef"));
-        assertEquals("red", instance.encodeForCSS("red"));
+        assertEquals("red", instance.encodeForCSS("red"));       
     }
-
-
-
+    
+    public void testCSSTripletLeadString() {
+    	Encoder instance = ESAPI.encoder();
+    	assertEquals("rgb(255,255,255)\\21 ", instance.encodeForCSS("rgb(255,255,255)!"));
+    	assertEquals("rgb(25%,25%,25%)\\21 ", instance.encodeForCSS("rgb(25%,25%,25%)!"));
+    }
+    public void testCSSTripletTailString() {
+		Encoder instance = ESAPI.encoder();
+    	assertEquals("\\24 field\\3d rgb(255,255,255)\\21 ", instance.encodeForCSS("$field=rgb(255,255,255)!"));
+    	assertEquals("\\24 field\\3d rgb(25%,25%,25%)\\21 ", instance.encodeForCSS("$field=rgb(25%,25%,25%)!"));
+    }
+    public void testCSSTripletStringPart() {
+		Encoder instance = ESAPI.encoder();
+    	assertEquals("\\24 field\\3d rgb(255,255,255)\\21 ", instance.encodeForCSS("$field=rgb(255,255,255)!"));
+    	assertEquals("\\24 field\\3d rgb(25%,25%,25%)\\21 ", instance.encodeForCSS("$field=rgb(25%,25%,25%)!"));
+    }
+    public void testCSSTripletStringMultiPart() {
+		Encoder instance = ESAPI.encoder();
+    	assertEquals("\\24 field\\3d rgb(255,255,255)\\21 \\20 \\24 field\\3d rgb(255,255,255)\\21 ", instance.encodeForCSS("$field=rgb(255,255,255)! $field=rgb(255,255,255)!"));
+    	assertEquals("\\24 field\\3d rgb(25%,25%,25%)\\21 \\20 \\24 field\\3d rgb(25%,25%,25%)\\21 ", instance.encodeForCSS("$field=rgb(25%,25%,25%)! $field=rgb(25%,25%,25%)!"));
+    	assertEquals("\\24 field\\3d rgb(255,255,255)\\21 \\20 \\24 field\\3d rgb(25%,25%,25%)\\21 ", instance.encodeForCSS("$field=rgb(255,255,255)! $field=rgb(25%,25%,25%)!"));
+    }
+       
+    
     /**
 	 * Test of encodeForJavaScript method, of class org.owasp.esapi.Encoder.
 	 */


### PR DESCRIPTION
@xeno6696  I think this achieves the capability you were looking for with Issue 494.  I have not worked much with the expectations of the Codec API so please let me know if I'm missing something.

As an aside, I did try to build the regex replacement capability as a separate class instance.  In future cases like this we may just need to figure out the regex and inject this piece into the process.

The new test cases pass, but I am currently seeing an issue with ValidatorTest.testIsValidSafeHTML and ValidatorTest.testGetValidSafeHTML.  I've verified that I am seeing the same failures across my fork of the develop branch.