### PR TITLE
Issue 530

### DIFF
--- a/src/main/java/org/owasp/esapi/logging/appender/ClientInfoSupplier.java
+++ b/src/main/java/org/owasp/esapi/logging/appender/ClientInfoSupplier.java
@@ -8,13 +8,26 @@ import javax.servlet.http.HttpSession;
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.User;
 
-public class ClientInfoSupplier implements Supplier <String> {
+/**
+ * Supplier which can provide a String representing the client-side connection
+ * information.
+ */
+public class ClientInfoSupplier implements Supplier<String> {
+	/** Session Attribute containing the ESAPI Session id. */
 	private static final String ESAPI_SESSION_ATTR = "ESAPI_SESSION";
+	/**
+	 * Minimum value for generating a random session value if one is not defined.
+	 */
 	private static final int ESAPI_SESSION_RAND_MIN = 0;
+	/**
+	 * Maximum value for generating a random session value if one is not defined.
+	 */
 	private static final int ESAPI_SESSION_RAND_MAX = 1000000;
 
-	private static final String USER_INFO_FORMAT = "%s:%s@%s";
+	/** Format for supplier output. */
+	private static final String USER_INFO_FORMAT = "%s:%s@%s"; // USER_NAME, SID, USER_HOST_ADDRESS
 
+	/** Whether to log the user info from this instance. */
 	private boolean logUserInfo = true;
 
 	@Override
@@ -24,13 +37,15 @@ public class ClientInfoSupplier implements Supplier <String> {
 		User user = ESAPI.authenticator().getCurrentUser();
 		if (logUserInfo && user != null) {
 			HttpServletRequest request = ESAPI.currentRequest();
-			// create a random session number for the user to represent the user's 'session', if it doesn't exist already
+			// create a random session number for the user to represent the user's
+			// 'session', if it doesn't exist already
 			String sid = "";
 			if (request != null) {
 				HttpSession session = request.getSession(false);
 				if (session != null) {
 					sid = (String) session.getAttribute(ESAPI_SESSION_ATTR);
-					// if there is no session ID for the user yet, we create one and store it in the user's session
+					// if there is no session ID for the user yet, we create one and store it in the
+					// user's session
 					if (sid == null) {
 						sid = "" + ESAPI.randomizer().getRandomInteger(ESAPI_SESSION_RAND_MIN, ESAPI_SESSION_RAND_MAX);
 						session.setAttribute(ESAPI_SESSION_ATTR, sid);
@@ -43,6 +58,11 @@ public class ClientInfoSupplier implements Supplier <String> {
 		return userInfo;
 	}
 
+	/**
+	 * Specify whether the instance should record the client info.
+	 * 
+	 * @param log {@code true} to record
+	 */
 	public void setLogUserInfo(boolean log) {
 		this.logUserInfo = log;
 	}

--- a/src/main/java/org/owasp/esapi/logging/appender/ClientInfoSupplier.java
+++ b/src/main/java/org/owasp/esapi/logging/appender/ClientInfoSupplier.java
@@ -1,3 +1,18 @@
+/**
+ * OWASP Enterprise Security API (ESAPI)
+ * 
+ * This file is part of the Open Web Application Security Project (OWASP)
+ * Enterprise Security API (ESAPI) project. For details, please see
+ * <a href="http://www.owasp.org/index.php/ESAPI">http://www.owasp.org/index.php/ESAPI</a>.
+ *
+ * Copyright (c) 2007 - The OWASP Foundation
+ * 
+ * The ESAPI is published by OWASP under the BSD license. You should read and accept the
+ * LICENSE before you use, modify, and/or redistribute this software.
+ * 
+ * @created 2019
+ */
+
 package org.owasp.esapi.logging.appender;
 
 import java.util.function.Supplier;

--- a/src/main/java/org/owasp/esapi/logging/appender/ClientInfoSupplier.java
+++ b/src/main/java/org/owasp/esapi/logging/appender/ClientInfoSupplier.java
@@ -16,7 +16,7 @@ public class ClientInfoSupplier implements Supplier<String> {
 	/** Default UserName string if the Authenticated user is null.*/
 	private static final String DEFAULT_USERNAME = "#ANONYMOUS#";
 	/** Default Last Host string if the Authenticated user is null.*/
-	private static final String DEFAULT_LAST_HOST = "";
+	private static final String DEFAULT_LAST_HOST = "#UNKNOWN_HOST#";
 	/** Session Attribute containing the ESAPI Session id. */
 	private static final String ESAPI_SESSION_ATTR = "ESAPI_SESSION";
 	/**

--- a/src/main/java/org/owasp/esapi/logging/appender/ClientInfoSupplier.java
+++ b/src/main/java/org/owasp/esapi/logging/appender/ClientInfoSupplier.java
@@ -13,6 +13,10 @@ import org.owasp.esapi.User;
  * information.
  */
 public class ClientInfoSupplier implements Supplier<String> {
+	/** Default UserName string if the Authenticated user is null.*/
+	private static final String DEFAULT_USERNAME = "#ANONYMOUS#";
+	/** Default Last Host string if the Authenticated user is null.*/
+	private static final String DEFAULT_LAST_HOST = "";
 	/** Session Attribute containing the ESAPI Session id. */
 	private static final String ESAPI_SESSION_ATTR = "ESAPI_SESSION";
 	/**
@@ -33,9 +37,8 @@ public class ClientInfoSupplier implements Supplier<String> {
 	@Override
 	public String get() {
 		String userInfo = "";
-		// log user information - username:session@ipaddr
-		User user = ESAPI.authenticator().getCurrentUser();
-		if (logUserInfo && user != null) {
+	
+		if (logUserInfo) {
 			HttpServletRequest request = ESAPI.currentRequest();
 			// create a random session number for the user to represent the user's
 			// 'session', if it doesn't exist already
@@ -52,8 +55,13 @@ public class ClientInfoSupplier implements Supplier<String> {
 					}
 				}
 			}
-
-			userInfo = String.format(USER_INFO_FORMAT, user.getAccountName(), sid, user.getLastHostAddress());
+			// log user information - username:session@ipaddr
+			User user = ESAPI.authenticator().getCurrentUser();
+			if (user == null) {
+				userInfo = String.format(USER_INFO_FORMAT, DEFAULT_USERNAME, sid, DEFAULT_LAST_HOST);
+			} else {
+				userInfo = String.format(USER_INFO_FORMAT, user.getAccountName(), sid, user.getLastHostAddress());
+			}
 		}
 		return userInfo;
 	}

--- a/src/main/java/org/owasp/esapi/logging/appender/ClientInfoSupplier.java
+++ b/src/main/java/org/owasp/esapi/logging/appender/ClientInfoSupplier.java
@@ -1,0 +1,50 @@
+package org.owasp.esapi.logging.appender;
+
+import java.util.function.Supplier;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.owasp.esapi.ESAPI;
+import org.owasp.esapi.User;
+
+public class ClientInfoSupplier implements Supplier <String> {
+	private static final String ESAPI_SESSION_ATTR = "ESAPI_SESSION";
+	private static final int ESAPI_SESSION_RAND_MIN = 0;
+	private static final int ESAPI_SESSION_RAND_MAX = 1000000;
+
+	private static final String USER_INFO_FORMAT = "%s:%s@%s";
+
+	private boolean logUserInfo = true;
+
+	@Override
+	public String get() {
+		String userInfo = "";
+		// log user information - username:session@ipaddr
+		User user = ESAPI.authenticator().getCurrentUser();
+		if (logUserInfo && user != null) {
+			HttpServletRequest request = ESAPI.currentRequest();
+			// create a random session number for the user to represent the user's 'session', if it doesn't exist already
+			String sid = "";
+			if (request != null) {
+				HttpSession session = request.getSession(false);
+				if (session != null) {
+					sid = (String) session.getAttribute(ESAPI_SESSION_ATTR);
+					// if there is no session ID for the user yet, we create one and store it in the user's session
+					if (sid == null) {
+						sid = "" + ESAPI.randomizer().getRandomInteger(ESAPI_SESSION_RAND_MIN, ESAPI_SESSION_RAND_MAX);
+						session.setAttribute(ESAPI_SESSION_ATTR, sid);
+					}
+				}
+			}
+
+			userInfo = String.format(USER_INFO_FORMAT, user.getAccountName(), sid, user.getLastHostAddress());
+		}
+		return userInfo;
+	}
+
+	public void setLogUserInfo(boolean log) {
+		this.logUserInfo = log;
+	}
+
+}

--- a/src/main/java/org/owasp/esapi/logging/appender/EventTypeLogSupplier.java
+++ b/src/main/java/org/owasp/esapi/logging/appender/EventTypeLogSupplier.java
@@ -4,10 +4,20 @@ import java.util.function.Supplier;
 
 import org.owasp.esapi.Logger.EventType;
 
+/**
+ * Supplier implementation which returns a consistent String representation of
+ * an EventType for logging
+ *
+ */
 public class EventTypeLogSupplier implements Supplier<String> {
-
+	/** EventType reference to supply log representation of. */
 	private final EventType eventType;
-	
+
+	/**
+	 * Ctr
+	 * 
+	 * @param evtyp EventType reference to supply log representation for
+	 */
 	public EventTypeLogSupplier(EventType evtyp) {
 		this.eventType = evtyp;
 	}
@@ -16,5 +26,4 @@ public class EventTypeLogSupplier implements Supplier<String> {
 	public String get() {
 		return eventType.toString();
 	}
-
 }

--- a/src/main/java/org/owasp/esapi/logging/appender/EventTypeLogSupplier.java
+++ b/src/main/java/org/owasp/esapi/logging/appender/EventTypeLogSupplier.java
@@ -1,3 +1,18 @@
+/**
+ * OWASP Enterprise Security API (ESAPI)
+ * 
+ * This file is part of the Open Web Application Security Project (OWASP)
+ * Enterprise Security API (ESAPI) project. For details, please see
+ * <a href="http://www.owasp.org/index.php/ESAPI">http://www.owasp.org/index.php/ESAPI</a>.
+ *
+ * Copyright (c) 2007 - The OWASP Foundation
+ * 
+ * The ESAPI is published by OWASP under the BSD license. You should read and accept the
+ * LICENSE before you use, modify, and/or redistribute this software.
+ * 
+ * @created 2019
+ */
+
 package org.owasp.esapi.logging.appender;
 
 import java.util.function.Supplier;

--- a/src/main/java/org/owasp/esapi/logging/appender/EventTypeLogSupplier.java
+++ b/src/main/java/org/owasp/esapi/logging/appender/EventTypeLogSupplier.java
@@ -1,0 +1,20 @@
+package org.owasp.esapi.logging.appender;
+
+import java.util.function.Supplier;
+
+import org.owasp.esapi.Logger.EventType;
+
+public class EventTypeLogSupplier implements Supplier<String> {
+
+	private final EventType eventType;
+	
+	public EventTypeLogSupplier(EventType evtyp) {
+		this.eventType = evtyp;
+	}
+
+	@Override
+	public String get() {
+		return eventType.toString();
+	}
+
+}

--- a/src/main/java/org/owasp/esapi/logging/appender/LogAppender.java
+++ b/src/main/java/org/owasp/esapi/logging/appender/LogAppender.java
@@ -1,0 +1,28 @@
+/**
+ * OWASP Enterprise Security API (ESAPI)
+ * 
+ * This file is part of the Open Web Application Security Project (OWASP)
+ * Enterprise Security API (ESAPI) project. For details, please see
+ * <a href="http://www.owasp.org/index.php/ESAPI">http://www.owasp.org/index.php/ESAPI</a>.
+ *
+ * Copyright (c) 2007 - The OWASP Foundation
+ * 
+ * The ESAPI is published by OWASP under the BSD license. You should read and accept the
+ * LICENSE before you use, modify, and/or redistribute this software.
+ * 
+ * @created 2018
+ */
+
+package org.owasp.esapi.logging.appender;
+
+import org.owasp.esapi.Logger.EventType;
+
+/**
+ * Contract interface for cleaning log message output.
+ *
+ */
+public interface LogAppender {
+
+	public String appendTo(String logName, EventType eventType, String message);
+
+}

--- a/src/main/java/org/owasp/esapi/logging/appender/LogAppender.java
+++ b/src/main/java/org/owasp/esapi/logging/appender/LogAppender.java
@@ -10,7 +10,7 @@
  * The ESAPI is published by OWASP under the BSD license. You should read and accept the
  * LICENSE before you use, modify, and/or redistribute this software.
  * 
- * @created 2018
+ * @created 2019
  */
 
 package org.owasp.esapi.logging.appender;
@@ -18,11 +18,18 @@ package org.owasp.esapi.logging.appender;
 import org.owasp.esapi.Logger.EventType;
 
 /**
- * Contract interface for cleaning log message output.
+ * Contract interface for appending content to a log message.
  *
  */
 public interface LogAppender {
 
+	/**
+	 * Creates a replacement Log Message and returns it to the caller.
+	 * @param logName name of the logger.
+	 * @param eventType EventType of the log event being processed.
+	 * @param message The original message.
+	 * @return Updated replacement message.
+	 */
 	public String appendTo(String logName, EventType eventType, String message);
 
 }

--- a/src/main/java/org/owasp/esapi/logging/appender/LogPrefixAppender.java
+++ b/src/main/java/org/owasp/esapi/logging/appender/LogPrefixAppender.java
@@ -2,28 +2,45 @@ package org.owasp.esapi.logging.appender;
 
 import org.owasp.esapi.Logger.EventType;
 
+/**
+ * LogAppender Implementation which can prefix the common logger information for
+ * EventType, Client data, and server data.
+ */
 public class LogPrefixAppender implements LogAppender {
-	private final String RESULT_FORMAT="[%s %s -> %s] %s";
-	
+	/** Output format used to assemble return values. */
+	private static final String RESULT_FORMAT = "[%s %s -> %s] %s";// EVENT_TYPE, CLIENT_INFO, SERVER_INFO, messageBody
+
+	/** Whether or not to record client information. */
 	private final boolean logClientInfo;
+	/** Whether or not to record server ip information. */
 	private final boolean logServerIp;
+	/** Whether or not to record application name. */
 	private final boolean logApplicationName;
+	/** Application Name to record. */
 	private final String appName;
-	
+
+	/**
+	 * Ctr.
+	 * 
+	 * @param logClientInfo      Whether or not to record client information
+	 * @param logServerIp        Whether or not to record server ip information
+	 * @param logApplicationName Whether or not to record application name
+	 * @param appName            Application Name to record.
+	 */
 	public LogPrefixAppender(boolean logClientInfo, boolean logServerIp, boolean logApplicationName, String appName) {
 		this.logClientInfo = logClientInfo;
 		this.logServerIp = logServerIp;
 		this.logApplicationName = logApplicationName;
 		this.appName = appName;
 	}
-	
+
 	@Override
 	public String appendTo(String logName, EventType eventType, String message) {
 		EventTypeLogSupplier eventTypeSupplier = new EventTypeLogSupplier(eventType);
-		
+
 		ClientInfoSupplier clientInfoSupplier = new ClientInfoSupplier();
 		clientInfoSupplier.setLogUserInfo(logClientInfo);
-		
+
 		ServerInfoSupplier serverInfoSupplier = new ServerInfoSupplier(logName);
 		serverInfoSupplier.setLogServerIp(logServerIp);
 		serverInfoSupplier.setLogApplicationName(logApplicationName, appName);
@@ -31,7 +48,7 @@ public class LogPrefixAppender implements LogAppender {
 		String eventTypeMsg = eventTypeSupplier.get();
 		String clientInfoMsg = clientInfoSupplier.get();
 		String serverInfoMsg = serverInfoSupplier.get();
-		
-		return String.format(RESULT_FORMAT, eventTypeMsg, clientInfoMsg,serverInfoMsg, message);
+
+		return String.format(RESULT_FORMAT, eventTypeMsg, clientInfoMsg, serverInfoMsg, message);
 	}
 }

--- a/src/main/java/org/owasp/esapi/logging/appender/LogPrefixAppender.java
+++ b/src/main/java/org/owasp/esapi/logging/appender/LogPrefixAppender.java
@@ -1,19 +1,24 @@
 package org.owasp.esapi.logging.appender;
 
-import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.Logger.EventType;
-import org.owasp.esapi.reference.DefaultSecurityConfiguration;
 
 public class LogPrefixAppender implements LogAppender {
 	private final String RESULT_FORMAT="[%s %s -> %s] %s";
 	
+	private final boolean logClientInfo;
+	private final boolean logServerIp;
+	private final boolean logApplicationName;
+	private final String appName;
+	
+	public LogPrefixAppender(boolean logClientInfo, boolean logServerIp, boolean logApplicationName, String appName) {
+		this.logClientInfo = logClientInfo;
+		this.logServerIp = logServerIp;
+		this.logApplicationName = logApplicationName;
+		this.appName = appName;
+	}
+	
 	@Override
 	public String appendTo(String logName, EventType eventType, String message) {
-		boolean logClientInfo = true;
-		boolean logApplicationName = ESAPI.securityConfiguration().getBooleanProp(DefaultSecurityConfiguration.LOG_APPLICATION_NAME);
-		String appName = ESAPI.securityConfiguration().getStringProp(DefaultSecurityConfiguration.APPLICATION_NAME);
-		boolean logServerIp = ESAPI.securityConfiguration().getBooleanProp(DefaultSecurityConfiguration.LOG_SERVER_IP);
-		
 		EventTypeLogSupplier eventTypeSupplier = new EventTypeLogSupplier(eventType);
 		
 		ClientInfoSupplier clientInfoSupplier = new ClientInfoSupplier();

--- a/src/main/java/org/owasp/esapi/logging/appender/LogPrefixAppender.java
+++ b/src/main/java/org/owasp/esapi/logging/appender/LogPrefixAppender.java
@@ -1,3 +1,18 @@
+/**
+ * OWASP Enterprise Security API (ESAPI)
+ * 
+ * This file is part of the Open Web Application Security Project (OWASP)
+ * Enterprise Security API (ESAPI) project. For details, please see
+ * <a href="http://www.owasp.org/index.php/ESAPI">http://www.owasp.org/index.php/ESAPI</a>.
+ *
+ * Copyright (c) 2007 - The OWASP Foundation
+ * 
+ * The ESAPI is published by OWASP under the BSD license. You should read and accept the
+ * LICENSE before you use, modify, and/or redistribute this software.
+ * 
+ * @created 2019
+ */
+
 package org.owasp.esapi.logging.appender;
 
 import org.owasp.esapi.Logger.EventType;

--- a/src/main/java/org/owasp/esapi/logging/appender/LogPrefixAppender.java
+++ b/src/main/java/org/owasp/esapi/logging/appender/LogPrefixAppender.java
@@ -1,0 +1,32 @@
+package org.owasp.esapi.logging.appender;
+
+import org.owasp.esapi.ESAPI;
+import org.owasp.esapi.Logger.EventType;
+import org.owasp.esapi.reference.DefaultSecurityConfiguration;
+
+public class LogPrefixAppender implements LogAppender {
+	private final String RESULT_FORMAT="[%s %s -> %s] %s";
+	
+	@Override
+	public String appendTo(String logName, EventType eventType, String message) {
+		boolean logClientInfo = true;
+		boolean logApplicationName = ESAPI.securityConfiguration().getBooleanProp(DefaultSecurityConfiguration.LOG_APPLICATION_NAME);
+		String appName = ESAPI.securityConfiguration().getStringProp(DefaultSecurityConfiguration.APPLICATION_NAME);
+		boolean logServerIp = ESAPI.securityConfiguration().getBooleanProp(DefaultSecurityConfiguration.LOG_SERVER_IP);
+		
+		EventTypeLogSupplier eventTypeSupplier = new EventTypeLogSupplier(eventType);
+		
+		ClientInfoSupplier clientInfoSupplier = new ClientInfoSupplier();
+		clientInfoSupplier.setLogUserInfo(logClientInfo);
+		
+		ServerInfoSupplier serverInfoSupplier = new ServerInfoSupplier(logName);
+		serverInfoSupplier.setLogServerIp(logServerIp);
+		serverInfoSupplier.setLogApplicationName(logApplicationName, appName);
+
+		String eventTypeMsg = eventTypeSupplier.get();
+		String clientInfoMsg = clientInfoSupplier.get();
+		String serverInfoMsg = serverInfoSupplier.get();
+		
+		return String.format(RESULT_FORMAT, eventTypeMsg, clientInfoMsg,serverInfoMsg, message);
+	}
+}

--- a/src/main/java/org/owasp/esapi/logging/appender/ServerInfoSupplier.java
+++ b/src/main/java/org/owasp/esapi/logging/appender/ServerInfoSupplier.java
@@ -6,13 +6,26 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.owasp.esapi.ESAPI;
 
-public class ServerInfoSupplier implements Supplier <String> {
+/**
+ * Supplier which can provide a String representing the server-side connection
+ * information.
+ */
+public class ServerInfoSupplier implements Supplier<String> {
+	/** Whether to log the server connection info. */
 	private boolean logServerIP = true;
+	/** Whether to log the application name. */
 	private boolean logAppName = true;
+	/** The application name to log. */
 	private String applicationName = "";
 
+	/** Reference to the associated logname/module name. */
 	private final String logName;
 
+	/**
+	 * Ctr.
+	 * 
+	 * @param logName Reference to the logName to record as the module information
+	 */
 	public ServerInfoSupplier(String logName) {
 		this.logName = logName;
 	}
@@ -32,16 +45,24 @@ public class ServerInfoSupplier implements Supplier <String> {
 
 		return appInfo.toString();
 	}
-	
+
+	/**
+	 * Specify whether the instance should record the server connection info.
+	 * 
+	 * @param log {@code true} to record
+	 */
 	public void setLogServerIp(boolean log) {
 		this.logServerIP = log;
 	}
-	
-	public void setLogApplicationName (boolean log, String appName) {
+
+	/**
+	 * Specify whether the instance should record the application name
+	 * 
+	 * @param log     {@code true} to record
+	 * @param appName String to record as the application name
+	 */
+	public void setLogApplicationName(boolean log, String appName) {
 		this.logAppName = log;
 		this.applicationName = appName;
 	}
-	
-	
-
 }

--- a/src/main/java/org/owasp/esapi/logging/appender/ServerInfoSupplier.java
+++ b/src/main/java/org/owasp/esapi/logging/appender/ServerInfoSupplier.java
@@ -1,0 +1,47 @@
+package org.owasp.esapi.logging.appender;
+
+import java.util.function.Supplier;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.owasp.esapi.ESAPI;
+
+public class ServerInfoSupplier implements Supplier <String> {
+	private boolean logServerIP = true;
+	private boolean logAppName = true;
+	private String applicationName = "";
+
+	private final String logName;
+
+	public ServerInfoSupplier(String logName) {
+		this.logName = logName;
+	}
+
+	@Override
+	public String get() {
+		// log server, port, app name, module name -- server:80/app/module
+		StringBuilder appInfo = new StringBuilder();
+		HttpServletRequest request = ESAPI.currentRequest();
+		if (request != null && logServerIP) {
+			appInfo.append(request.getLocalAddr()).append(":").append(request.getLocalPort());
+		}
+		if (logAppName) {
+			appInfo.append("/").append(applicationName);
+		}
+		appInfo.append("/").append(logName);
+
+		return appInfo.toString();
+	}
+	
+	public void setLogServerIp(boolean log) {
+		this.logServerIP = log;
+	}
+	
+	public void setLogApplicationName (boolean log, String appName) {
+		this.logAppName = log;
+		this.applicationName = appName;
+	}
+	
+	
+
+}

--- a/src/main/java/org/owasp/esapi/logging/appender/ServerInfoSupplier.java
+++ b/src/main/java/org/owasp/esapi/logging/appender/ServerInfoSupplier.java
@@ -1,3 +1,18 @@
+/**
+ * OWASP Enterprise Security API (ESAPI)
+ * 
+ * This file is part of the Open Web Application Security Project (OWASP)
+ * Enterprise Security API (ESAPI) project. For details, please see
+ * <a href="http://www.owasp.org/index.php/ESAPI">http://www.owasp.org/index.php/ESAPI</a>.
+ *
+ * Copyright (c) 2007 - The OWASP Foundation
+ * 
+ * The ESAPI is published by OWASP under the BSD license. You should read and accept the
+ * LICENSE before you use, modify, and/or redistribute this software.
+ * 
+ * @created 2019
+ */
+
 package org.owasp.esapi.logging.appender;
 
 import java.util.function.Supplier;

--- a/src/main/java/org/owasp/esapi/logging/slf4j/Slf4JLogBridgeImpl.java
+++ b/src/main/java/org/owasp/esapi/logging/slf4j/Slf4JLogBridgeImpl.java
@@ -58,8 +58,10 @@ public class Slf4JLogBridgeImpl implements Slf4JLogBridge {
             throw new IllegalArgumentException("Unable to lookup SLF4J level mapping for esapi value of " + esapiLevel);
         }
         if (handler.isEnabled(logger)) {
+        	String fullMessage = appender.appendTo(logger.getName(), type, message);
+            String cleanString = scrubber.cleanMessage(fullMessage);
+            
             Marker typeMarker = MARKER_FACTORY.getMarker(type.toString());
-            String cleanString = scrubber.cleanMessage(message);
             handler.log(logger, typeMarker, cleanString);
         }
     }

--- a/src/main/java/org/owasp/esapi/logging/slf4j/Slf4JLogFactory.java
+++ b/src/main/java/org/owasp/esapi/logging/slf4j/Slf4JLogFactory.java
@@ -23,6 +23,8 @@ import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.LogFactory;
 import org.owasp.esapi.Logger;
 import org.owasp.esapi.codecs.HTMLEntityCodec;
+import org.owasp.esapi.logging.appender.LogAppender;
+import org.owasp.esapi.logging.appender.LogPrefixAppender;
 import org.owasp.esapi.logging.cleaning.CodecLogScrubber;
 import org.owasp.esapi.logging.cleaning.CompositeLogScrubber;
 import org.owasp.esapi.logging.cleaning.LogScrubber;
@@ -44,6 +46,8 @@ public class Slf4JLogFactory implements LogFactory {
     private static final char[] IMMUNE_SLF4J_HTML = {',', '.', '-', '_', ' ',BACKSLASH, OPEN_SLF_FORMAT, CLOSE_SLF_FORMAT };
     /** Codec being used to clean messages for logging.*/
     private static final HTMLEntityCodec HTML_CODEC = new HTMLEntityCodec();
+    /** Log appender instance.*/
+    private static LogAppender SLF4J_LOG_APPENDER;
     /** Log cleaner instance.*/
     private static LogScrubber SLF4J_LOG_SCRUBBER;
     /** Bridge class for mapping esapi -> slf4j log levels.*/
@@ -52,6 +56,7 @@ public class Slf4JLogFactory implements LogFactory {
     static {
         boolean encodeLog = ESAPI.securityConfiguration().getBooleanProp(DefaultSecurityConfiguration.LOG_ENCODING_REQUIRED);
         SLF4J_LOG_SCRUBBER = createLogScrubber(encodeLog);
+        SLF4J_LOG_APPENDER = createLogAppender();
         
         Map<Integer, Slf4JLogLevelHandler> levelLookup = new HashMap<>();
         levelLookup.put(Logger.ALL, Slf4JLogLevelHandlers.TRACE);
@@ -63,7 +68,7 @@ public class Slf4JLogFactory implements LogFactory {
         levelLookup.put(Logger.FATAL, Slf4JLogLevelHandlers.ERROR);
         //LEVEL.OFF not used.  If it's off why would we try to log it?
         
-        LOG_BRIDGE = new Slf4JLogBridgeImpl(SLF4J_LOG_SCRUBBER, levelLookup);
+        LOG_BRIDGE = new Slf4JLogBridgeImpl(SLF4J_LOG_APPENDER, SLF4J_LOG_SCRUBBER, levelLookup);
     }
     
     /**
@@ -81,6 +86,15 @@ public class Slf4JLogFactory implements LogFactory {
         
         return new CompositeLogScrubber(messageScrubber);
         
+    }
+    
+    /**
+     * Populates the default log appender for use in factory-created loggers.
+     * 
+     * @return LogAppender instance.
+     */
+    /*package*/ static LogAppender createLogAppender() {
+       return new LogPrefixAppender();        
     }
     
     

--- a/src/main/java/org/owasp/esapi/logging/slf4j/Slf4JLogFactory.java
+++ b/src/main/java/org/owasp/esapi/logging/slf4j/Slf4JLogFactory.java
@@ -56,7 +56,12 @@ public class Slf4JLogFactory implements LogFactory {
     static {
         boolean encodeLog = ESAPI.securityConfiguration().getBooleanProp(DefaultSecurityConfiguration.LOG_ENCODING_REQUIRED);
         SLF4J_LOG_SCRUBBER = createLogScrubber(encodeLog);
-        SLF4J_LOG_APPENDER = createLogAppender();
+        
+    	boolean logClientInfo = true;
+		boolean logApplicationName = ESAPI.securityConfiguration().getBooleanProp(DefaultSecurityConfiguration.LOG_APPLICATION_NAME);
+		String appName = ESAPI.securityConfiguration().getStringProp(DefaultSecurityConfiguration.APPLICATION_NAME);
+		boolean logServerIp = ESAPI.securityConfiguration().getBooleanProp(DefaultSecurityConfiguration.LOG_SERVER_IP);
+        SLF4J_LOG_APPENDER = createLogAppender(logClientInfo, logServerIp, logApplicationName, appName);
         
         Map<Integer, Slf4JLogLevelHandler> levelLookup = new HashMap<>();
         levelLookup.put(Logger.ALL, Slf4JLogLevelHandlers.TRACE);
@@ -90,11 +95,15 @@ public class Slf4JLogFactory implements LogFactory {
     
     /**
      * Populates the default log appender for use in factory-created loggers.
+     * @param appName 
+     * @param logApplicationName 
+     * @param logServerIp 
+     * @param logClientInfo 
      * 
      * @return LogAppender instance.
      */
-    /*package*/ static LogAppender createLogAppender() {
-       return new LogPrefixAppender();        
+    /*package*/ static LogAppender createLogAppender(boolean logClientInfo, boolean logServerIp, boolean logApplicationName, String appName) {
+       return new LogPrefixAppender(logClientInfo, logServerIp, logApplicationName, appName);       
     }
     
     

--- a/src/test/java/org/owasp/esapi/logging/appender/ClientInfoSupplierTest.java
+++ b/src/test/java/org/owasp/esapi/logging/appender/ClientInfoSupplierTest.java
@@ -4,7 +4,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -16,22 +15,20 @@ import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.Randomizer;
 import org.owasp.esapi.User;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ESAPI.class})
-//https://www.gyanblog.com/gyan/20-linkage-error-loader-constraint-violation-junit-test-case-development-issue/
-//Does not correct issue with mocking User class
-//@PowerMockIgnore("org.owasp.esapi.User")
-@Ignore("Need Help figuring out why I cannot mock org.owasp.esapi.User")
+@PowerMockIgnore("javax.security.*") //Required since User extends javax.security.Principal
 public class ClientInfoSupplierTest {
 	private static final String ESAPI_SESSION_ATTR = "ESAPI_SESSION";
 	
 	@Rule
     public TestName testName = new TestName();
 	
-	private HttpServletRequest request;
+	private HttpServletRequest mockRequest;
 	private HttpSession mockSession;
 	private Authenticator mockAuth;
 	private Randomizer mockRand;
@@ -41,18 +38,17 @@ public class ClientInfoSupplierTest {
 	public void before() throws Exception {
 		mockAuth = PowerMockito.mock(Authenticator.class); 
 		mockRand = PowerMockito.mock(Randomizer.class); 
+		mockRequest = PowerMockito.mock(HttpServletRequest.class);
+		mockSession = PowerMockito.mock(HttpSession.class);
+		mockUser = PowerMockito.mock(User.class);
+		
 		PowerMockito.mockStatic(ESAPI.class);
-		PowerMockito.when(ESAPI.class, "currentRequest").thenReturn(request);
+		PowerMockito.when(ESAPI.class, "currentRequest").thenReturn(mockRequest);
 		PowerMockito.when(ESAPI.class, "authenticator").thenReturn(mockAuth);
 		PowerMockito.when(ESAPI.class, "randomizer").thenReturn(mockRand);
 		
-		request = PowerMockito.mock(HttpServletRequest.class);
-		mockSession = PowerMockito.mock(HttpSession.class);
-		PowerMockito.when(request.getSession(ArgumentMatchers.anyBoolean())).thenReturn(mockSession);
+		PowerMockito.when(mockRequest.getSession(false)).thenReturn(mockSession);
 		PowerMockito.when(mockSession.getAttribute(ESAPI_SESSION_ATTR)).thenReturn(testName.getMethodName()+ "-SESSION");
-		
-		//FIXME:  I cannot mock this interface.
-		mockUser = PowerMockito.mock(User.class);
 		
 		//Session value generation
 		PowerMockito.when(mockRand.getRandomInteger(ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())).thenReturn(55555);
@@ -71,6 +67,14 @@ public class ClientInfoSupplierTest {
 		String result = cis.get();
 		
 		org.junit.Assert.assertEquals(testName.getMethodName() + "-USER:"+ testName.getMethodName() + "-SESSION@"+testName.getMethodName() + "-HOST_ADDR", result);
+		
+		Mockito.verify(mockAuth,Mockito.times(1)).getCurrentUser();
+		Mockito.verify(mockRequest,Mockito.times(1)).getSession(false);
+		Mockito.verify(mockSession,Mockito.times(1)).getAttribute(ESAPI_SESSION_ATTR);
+		Mockito.verify(mockUser,Mockito.times(1)).getAccountName();
+		Mockito.verify(mockUser,Mockito.times(1)).getLastHostAddress();
+		
+		Mockito.verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
 	}
 	
 	@Test
@@ -80,6 +84,10 @@ public class ClientInfoSupplierTest {
 		String result = cis.get();
 		
 		org.junit.Assert.assertTrue(result.isEmpty());
+		
+		Mockito.verify(mockAuth,Mockito.times(1)).getCurrentUser();
+		
+		Mockito.verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
 	}
 	
 	@Test
@@ -90,6 +98,10 @@ public class ClientInfoSupplierTest {
 		String result = cis.get();
 		
 		org.junit.Assert.assertTrue(result.isEmpty());
+		
+		Mockito.verify(mockAuth,Mockito.times(1)).getCurrentUser();
+		
+		Mockito.verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
 	}
 	
 	@Test
@@ -101,17 +113,32 @@ public class ClientInfoSupplierTest {
 		
 		//sid is empty when request is null		
 		org.junit.Assert.assertEquals(testName.getMethodName() + "-USER:@"+testName.getMethodName() + "-HOST_ADDR", result);
+		
+		Mockito.verify(mockAuth,Mockito.times(1)).getCurrentUser();
+		Mockito.verify(mockUser,Mockito.times(1)).getAccountName();
+		Mockito.verify(mockUser,Mockito.times(1)).getLastHostAddress();
+		
+		Mockito.verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
 	}
 	
 	@Test
 	public void testNullSession() throws Exception {
-		PowerMockito.when(request.getSession()).thenReturn(null);
+		PowerMockito.when(mockRequest.getSession(false)).thenReturn(null);
 		ClientInfoSupplier cis = new ClientInfoSupplier();
 		cis.setLogUserInfo(true);
 		String result = cis.get();
 		
 		//sid is empty when session is null		
 		org.junit.Assert.assertEquals(testName.getMethodName() + "-USER:@"+testName.getMethodName() + "-HOST_ADDR", result);
+		
+		
+		Mockito.verify(mockAuth,Mockito.times(1)).getCurrentUser();
+		Mockito.verify(mockRequest,Mockito.times(1)).getSession(false);
+		Mockito.verify(mockUser,Mockito.times(1)).getAccountName();
+		Mockito.verify(mockUser,Mockito.times(1)).getLastHostAddress();
+		
+		
+		Mockito.verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
 	}
 	
 	
@@ -125,6 +152,15 @@ public class ClientInfoSupplierTest {
 		
 		//sid is empty when session is null		
 		org.junit.Assert.assertEquals(testName.getMethodName() + "-USER:55555@"+testName.getMethodName() + "-HOST_ADDR", result);
+		
+		Mockito.verify(mockAuth,Mockito.times(1)).getCurrentUser();
+		Mockito.verify(mockRequest,Mockito.times(1)).getSession(false);
+		Mockito.verify(mockSession,Mockito.times(1)).getAttribute(ESAPI_SESSION_ATTR);
 		Mockito.verify(mockSession, Mockito.times(1)).setAttribute(ESAPI_SESSION_ATTR, (""+55555));
+		Mockito.verify(mockRand, Mockito.times(1)).getRandomInteger(ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt());
+		Mockito.verify(mockUser,Mockito.times(1)).getAccountName();
+		Mockito.verify(mockUser,Mockito.times(1)).getLastHostAddress();
+		
+		Mockito.verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
 	}
 }

--- a/src/test/java/org/owasp/esapi/logging/appender/ClientInfoSupplierTest.java
+++ b/src/test/java/org/owasp/esapi/logging/appender/ClientInfoSupplierTest.java
@@ -92,8 +92,6 @@ public class ClientInfoSupplierTest {
 		
 		assertTrue(result.isEmpty());
 		
-		verify(mockAuth,times(1)).getCurrentUser();
-		
 		verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
 	}
 	
@@ -104,9 +102,11 @@ public class ClientInfoSupplierTest {
 		cis.setLogUserInfo(true);
 		String result = cis.get();
 		
-		assertTrue(result.isEmpty());
+		assertEquals("#ANONYMOUS#:"+testName.getMethodName()+ "-SESSION@", result);
 		
 		verify(mockAuth,times(1)).getCurrentUser();
+		verify(mockRequest,times(1)).getSession(false);
+		verify(mockSession,times(1)).getAttribute(ESAPI_SESSION_ATTR);
 		
 		verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
 	}

--- a/src/test/java/org/owasp/esapi/logging/appender/ClientInfoSupplierTest.java
+++ b/src/test/java/org/owasp/esapi/logging/appender/ClientInfoSupplierTest.java
@@ -1,0 +1,130 @@
+package org.owasp.esapi.logging.appender;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.owasp.esapi.Authenticator;
+import org.owasp.esapi.ESAPI;
+import org.owasp.esapi.Randomizer;
+import org.owasp.esapi.User;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ESAPI.class})
+//https://www.gyanblog.com/gyan/20-linkage-error-loader-constraint-violation-junit-test-case-development-issue/
+//Does not correct issue with mocking User class
+//@PowerMockIgnore("org.owasp.esapi.User")
+@Ignore("Need Help figuring out why I cannot mock org.owasp.esapi.User")
+public class ClientInfoSupplierTest {
+	private static final String ESAPI_SESSION_ATTR = "ESAPI_SESSION";
+	
+	@Rule
+    public TestName testName = new TestName();
+	
+	private HttpServletRequest request;
+	private HttpSession mockSession;
+	private Authenticator mockAuth;
+	private Randomizer mockRand;
+	private User mockUser;
+	
+	@Before
+	public void before() throws Exception {
+		mockAuth = PowerMockito.mock(Authenticator.class); 
+		mockRand = PowerMockito.mock(Randomizer.class); 
+		PowerMockito.mockStatic(ESAPI.class);
+		PowerMockito.when(ESAPI.class, "currentRequest").thenReturn(request);
+		PowerMockito.when(ESAPI.class, "authenticator").thenReturn(mockAuth);
+		PowerMockito.when(ESAPI.class, "randomizer").thenReturn(mockRand);
+		
+		request = PowerMockito.mock(HttpServletRequest.class);
+		mockSession = PowerMockito.mock(HttpSession.class);
+		PowerMockito.when(request.getSession(ArgumentMatchers.anyBoolean())).thenReturn(mockSession);
+		PowerMockito.when(mockSession.getAttribute(ESAPI_SESSION_ATTR)).thenReturn(testName.getMethodName()+ "-SESSION");
+		
+		//FIXME:  I cannot mock this interface.
+		mockUser = PowerMockito.mock(User.class);
+		
+		//Session value generation
+		PowerMockito.when(mockRand.getRandomInteger(ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())).thenReturn(55555);
+		 
+		Mockito.when(mockUser.getAccountName()).thenReturn(testName.getMethodName() + "-USER");
+		Mockito.when(mockUser.getLastHostAddress()).thenReturn(testName.getMethodName() + "-HOST_ADDR");
+		
+	     
+	    Mockito.when(mockAuth.getCurrentUser()).thenReturn(mockUser);
+	}
+	
+	@Test
+	public void testHappyPath() throws Exception {
+		ClientInfoSupplier cis = new ClientInfoSupplier();
+		cis.setLogUserInfo(true);
+		String result = cis.get();
+		
+		org.junit.Assert.assertEquals(testName.getMethodName() + "-USER:"+ testName.getMethodName() + "-SESSION@"+testName.getMethodName() + "-HOST_ADDR", result);
+	}
+	
+	@Test
+	public void testLogUserOff() {
+		ClientInfoSupplier cis = new ClientInfoSupplier();
+		cis.setLogUserInfo(false);
+		String result = cis.get();
+		
+		org.junit.Assert.assertTrue(result.isEmpty());
+	}
+	
+	@Test
+	public void testLogUserNull() {
+		Mockito.when(mockAuth.getCurrentUser()).thenReturn(null);
+		ClientInfoSupplier cis = new ClientInfoSupplier();
+		cis.setLogUserInfo(true);
+		String result = cis.get();
+		
+		org.junit.Assert.assertTrue(result.isEmpty());
+	}
+	
+	@Test
+	public void testNullRequest() throws Exception {
+		PowerMockito.when(ESAPI.class, "currentRequest").thenReturn(null);
+		ClientInfoSupplier cis = new ClientInfoSupplier();
+		cis.setLogUserInfo(true);
+		String result = cis.get();
+		
+		//sid is empty when request is null		
+		org.junit.Assert.assertEquals(testName.getMethodName() + "-USER:@"+testName.getMethodName() + "-HOST_ADDR", result);
+	}
+	
+	@Test
+	public void testNullSession() throws Exception {
+		PowerMockito.when(request.getSession()).thenReturn(null);
+		ClientInfoSupplier cis = new ClientInfoSupplier();
+		cis.setLogUserInfo(true);
+		String result = cis.get();
+		
+		//sid is empty when session is null		
+		org.junit.Assert.assertEquals(testName.getMethodName() + "-USER:@"+testName.getMethodName() + "-HOST_ADDR", result);
+	}
+	
+	
+	
+	@Test
+	public void testNullEsapiSession() throws Exception {
+		PowerMockito.when(mockSession.getAttribute(ESAPI_SESSION_ATTR)).thenReturn(null);
+		ClientInfoSupplier cis = new ClientInfoSupplier();
+		cis.setLogUserInfo(true);
+		String result = cis.get();
+		
+		//sid is empty when session is null		
+		org.junit.Assert.assertEquals(testName.getMethodName() + "-USER:55555@"+testName.getMethodName() + "-HOST_ADDR", result);
+		Mockito.verify(mockSession, Mockito.times(1)).setAttribute(ESAPI_SESSION_ATTR, (""+55555));
+	}
+}

--- a/src/test/java/org/owasp/esapi/logging/appender/ClientInfoSupplierTest.java
+++ b/src/test/java/org/owasp/esapi/logging/appender/ClientInfoSupplierTest.java
@@ -102,7 +102,7 @@ public class ClientInfoSupplierTest {
 		cis.setLogUserInfo(true);
 		String result = cis.get();
 		
-		assertEquals("#ANONYMOUS#:"+testName.getMethodName()+ "-SESSION@", result);
+		assertEquals("#ANONYMOUS#:"+testName.getMethodName()+ "-SESSION@#UNKNOWN_HOST#", result);
 		
 		verify(mockAuth,times(1)).getCurrentUser();
 		verify(mockRequest,times(1)).getSession(false);

--- a/src/test/java/org/owasp/esapi/logging/appender/ClientInfoSupplierTest.java
+++ b/src/test/java/org/owasp/esapi/logging/appender/ClientInfoSupplierTest.java
@@ -1,5 +1,14 @@
 package org.owasp.esapi.logging.appender;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
@@ -9,12 +18,10 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
 import org.owasp.esapi.Authenticator;
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.Randomizer;
 import org.owasp.esapi.User;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -36,28 +43,28 @@ public class ClientInfoSupplierTest {
 	
 	@Before
 	public void before() throws Exception {
-		mockAuth = PowerMockito.mock(Authenticator.class); 
-		mockRand = PowerMockito.mock(Randomizer.class); 
-		mockRequest = PowerMockito.mock(HttpServletRequest.class);
-		mockSession = PowerMockito.mock(HttpSession.class);
-		mockUser = PowerMockito.mock(User.class);
+		mockAuth =mock(Authenticator.class); 
+		mockRand =mock(Randomizer.class); 
+		mockRequest =mock(HttpServletRequest.class);
+		mockSession =mock(HttpSession.class);
+		mockUser =mock(User.class);
 		
-		PowerMockito.mockStatic(ESAPI.class);
-		PowerMockito.when(ESAPI.class, "currentRequest").thenReturn(mockRequest);
-		PowerMockito.when(ESAPI.class, "authenticator").thenReturn(mockAuth);
-		PowerMockito.when(ESAPI.class, "randomizer").thenReturn(mockRand);
+		mockStatic(ESAPI.class);
+		when(ESAPI.class, "currentRequest").thenReturn(mockRequest);
+		when(ESAPI.class, "authenticator").thenReturn(mockAuth);
+		when(ESAPI.class, "randomizer").thenReturn(mockRand);
 		
-		PowerMockito.when(mockRequest.getSession(false)).thenReturn(mockSession);
-		PowerMockito.when(mockSession.getAttribute(ESAPI_SESSION_ATTR)).thenReturn(testName.getMethodName()+ "-SESSION");
+		when(mockRequest.getSession(false)).thenReturn(mockSession);
+		when(mockSession.getAttribute(ESAPI_SESSION_ATTR)).thenReturn(testName.getMethodName()+ "-SESSION");
 		
 		//Session value generation
-		PowerMockito.when(mockRand.getRandomInteger(ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())).thenReturn(55555);
+		when(mockRand.getRandomInteger(ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())).thenReturn(55555);
 		 
-		Mockito.when(mockUser.getAccountName()).thenReturn(testName.getMethodName() + "-USER");
-		Mockito.when(mockUser.getLastHostAddress()).thenReturn(testName.getMethodName() + "-HOST_ADDR");
+		when(mockUser.getAccountName()).thenReturn(testName.getMethodName() + "-USER");
+		when(mockUser.getLastHostAddress()).thenReturn(testName.getMethodName() + "-HOST_ADDR");
 		
 	     
-	    Mockito.when(mockAuth.getCurrentUser()).thenReturn(mockUser);
+	    when(mockAuth.getCurrentUser()).thenReturn(mockUser);
 	}
 	
 	@Test
@@ -66,15 +73,15 @@ public class ClientInfoSupplierTest {
 		cis.setLogUserInfo(true);
 		String result = cis.get();
 		
-		org.junit.Assert.assertEquals(testName.getMethodName() + "-USER:"+ testName.getMethodName() + "-SESSION@"+testName.getMethodName() + "-HOST_ADDR", result);
+		assertEquals(testName.getMethodName() + "-USER:"+ testName.getMethodName() + "-SESSION@"+testName.getMethodName() + "-HOST_ADDR", result);
 		
-		Mockito.verify(mockAuth,Mockito.times(1)).getCurrentUser();
-		Mockito.verify(mockRequest,Mockito.times(1)).getSession(false);
-		Mockito.verify(mockSession,Mockito.times(1)).getAttribute(ESAPI_SESSION_ATTR);
-		Mockito.verify(mockUser,Mockito.times(1)).getAccountName();
-		Mockito.verify(mockUser,Mockito.times(1)).getLastHostAddress();
+		verify(mockAuth,times(1)).getCurrentUser();
+		verify(mockRequest,times(1)).getSession(false);
+		verify(mockSession,times(1)).getAttribute(ESAPI_SESSION_ATTR);
+		verify(mockUser,times(1)).getAccountName();
+		verify(mockUser,times(1)).getLastHostAddress();
 		
-		Mockito.verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
+		verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
 	}
 	
 	@Test
@@ -83,84 +90,84 @@ public class ClientInfoSupplierTest {
 		cis.setLogUserInfo(false);
 		String result = cis.get();
 		
-		org.junit.Assert.assertTrue(result.isEmpty());
+		assertTrue(result.isEmpty());
 		
-		Mockito.verify(mockAuth,Mockito.times(1)).getCurrentUser();
+		verify(mockAuth,times(1)).getCurrentUser();
 		
-		Mockito.verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
+		verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
 	}
 	
 	@Test
 	public void testLogUserNull() {
-		Mockito.when(mockAuth.getCurrentUser()).thenReturn(null);
+		when(mockAuth.getCurrentUser()).thenReturn(null);
 		ClientInfoSupplier cis = new ClientInfoSupplier();
 		cis.setLogUserInfo(true);
 		String result = cis.get();
 		
-		org.junit.Assert.assertTrue(result.isEmpty());
+		assertTrue(result.isEmpty());
 		
-		Mockito.verify(mockAuth,Mockito.times(1)).getCurrentUser();
+		verify(mockAuth,times(1)).getCurrentUser();
 		
-		Mockito.verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
+		verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
 	}
 	
 	@Test
 	public void testNullRequest() throws Exception {
-		PowerMockito.when(ESAPI.class, "currentRequest").thenReturn(null);
+		when(ESAPI.class, "currentRequest").thenReturn(null);
 		ClientInfoSupplier cis = new ClientInfoSupplier();
 		cis.setLogUserInfo(true);
 		String result = cis.get();
 		
 		//sid is empty when request is null		
-		org.junit.Assert.assertEquals(testName.getMethodName() + "-USER:@"+testName.getMethodName() + "-HOST_ADDR", result);
+		assertEquals(testName.getMethodName() + "-USER:@"+testName.getMethodName() + "-HOST_ADDR", result);
 		
-		Mockito.verify(mockAuth,Mockito.times(1)).getCurrentUser();
-		Mockito.verify(mockUser,Mockito.times(1)).getAccountName();
-		Mockito.verify(mockUser,Mockito.times(1)).getLastHostAddress();
+		verify(mockAuth,times(1)).getCurrentUser();
+		verify(mockUser,times(1)).getAccountName();
+		verify(mockUser,times(1)).getLastHostAddress();
 		
-		Mockito.verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
+		verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
 	}
 	
 	@Test
 	public void testNullSession() throws Exception {
-		PowerMockito.when(mockRequest.getSession(false)).thenReturn(null);
+		when(mockRequest.getSession(false)).thenReturn(null);
 		ClientInfoSupplier cis = new ClientInfoSupplier();
 		cis.setLogUserInfo(true);
 		String result = cis.get();
 		
 		//sid is empty when session is null		
-		org.junit.Assert.assertEquals(testName.getMethodName() + "-USER:@"+testName.getMethodName() + "-HOST_ADDR", result);
+		assertEquals(testName.getMethodName() + "-USER:@"+testName.getMethodName() + "-HOST_ADDR", result);
 		
 		
-		Mockito.verify(mockAuth,Mockito.times(1)).getCurrentUser();
-		Mockito.verify(mockRequest,Mockito.times(1)).getSession(false);
-		Mockito.verify(mockUser,Mockito.times(1)).getAccountName();
-		Mockito.verify(mockUser,Mockito.times(1)).getLastHostAddress();
+		verify(mockAuth,times(1)).getCurrentUser();
+		verify(mockRequest,times(1)).getSession(false);
+		verify(mockUser,times(1)).getAccountName();
+		verify(mockUser,times(1)).getLastHostAddress();
 		
 		
-		Mockito.verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
+		verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
 	}
 	
 	
 	
 	@Test
 	public void testNullEsapiSession() throws Exception {
-		PowerMockito.when(mockSession.getAttribute(ESAPI_SESSION_ATTR)).thenReturn(null);
+		when(mockSession.getAttribute(ESAPI_SESSION_ATTR)).thenReturn(null);
 		ClientInfoSupplier cis = new ClientInfoSupplier();
 		cis.setLogUserInfo(true);
 		String result = cis.get();
 		
 		//sid is empty when session is null		
-		org.junit.Assert.assertEquals(testName.getMethodName() + "-USER:55555@"+testName.getMethodName() + "-HOST_ADDR", result);
+		assertEquals(testName.getMethodName() + "-USER:55555@"+testName.getMethodName() + "-HOST_ADDR", result);
 		
-		Mockito.verify(mockAuth,Mockito.times(1)).getCurrentUser();
-		Mockito.verify(mockRequest,Mockito.times(1)).getSession(false);
-		Mockito.verify(mockSession,Mockito.times(1)).getAttribute(ESAPI_SESSION_ATTR);
-		Mockito.verify(mockSession, Mockito.times(1)).setAttribute(ESAPI_SESSION_ATTR, (""+55555));
-		Mockito.verify(mockRand, Mockito.times(1)).getRandomInteger(ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt());
-		Mockito.verify(mockUser,Mockito.times(1)).getAccountName();
-		Mockito.verify(mockUser,Mockito.times(1)).getLastHostAddress();
+		verify(mockAuth,times(1)).getCurrentUser();
+		verify(mockRequest,times(1)).getSession(false);
+		verify(mockSession,times(1)).getAttribute(ESAPI_SESSION_ATTR);
+		verify(mockSession, times(1)).setAttribute(ESAPI_SESSION_ATTR, (""+55555));
+		verify(mockRand, times(1)).getRandomInteger(ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt());
+		verify(mockUser,times(1)).getAccountName();
+		verify(mockUser,times(1)).getLastHostAddress();
 		
-		Mockito.verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
+		verifyNoMoreInteractions(mockAuth, mockRand, mockRequest, mockSession, mockUser);
 	}
 }

--- a/src/test/java/org/owasp/esapi/logging/appender/EventTypeLogSupplierTest.java
+++ b/src/test/java/org/owasp/esapi/logging/appender/EventTypeLogSupplierTest.java
@@ -1,5 +1,7 @@
 package org.owasp.esapi.logging.appender;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 import org.owasp.esapi.Logger;
 import org.owasp.esapi.Logger.EventType;
@@ -11,6 +13,6 @@ public class EventTypeLogSupplierTest {
 		EventType eventType = Logger.EVENT_UNSPECIFIED;
 		EventTypeLogSupplier supplier = new EventTypeLogSupplier(eventType);
 		
-		org.junit.Assert.assertEquals(eventType.toString(), supplier.get());
+		assertEquals(eventType.toString(), supplier.get());
 	}
 }

--- a/src/test/java/org/owasp/esapi/logging/appender/EventTypeLogSupplierTest.java
+++ b/src/test/java/org/owasp/esapi/logging/appender/EventTypeLogSupplierTest.java
@@ -1,0 +1,16 @@
+package org.owasp.esapi.logging.appender;
+
+import org.junit.Test;
+import org.owasp.esapi.Logger;
+import org.owasp.esapi.Logger.EventType;
+
+public class EventTypeLogSupplierTest {
+
+	@Test
+	public void testEventTypeLog() {
+		EventType eventType = Logger.EVENT_UNSPECIFIED;
+		EventTypeLogSupplier supplier = new EventTypeLogSupplier(eventType);
+		
+		org.junit.Assert.assertEquals(eventType.toString(), supplier.get());
+	}
+}

--- a/src/test/java/org/owasp/esapi/logging/appender/LogPrefixAppenderTest.java
+++ b/src/test/java/org/owasp/esapi/logging/appender/LogPrefixAppenderTest.java
@@ -1,100 +1,106 @@
 package org.owasp.esapi.logging.appender;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.owasp.esapi.Logger;
 import org.owasp.esapi.Logger.EventType;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import org.junit.Assert;
-
 @RunWith(PowerMockRunner.class)
-@PrepareForTest (LogPrefixAppender.class)
+@PrepareForTest(LogPrefixAppender.class)
 public class LogPrefixAppenderTest {
 	@Rule
-    public TestName testName = new TestName();
+	public TestName testName = new TestName();
 
 	private EventTypeLogSupplier etlsSpy;
 	private String etlsSpyGet = "EVENT_TYPE";
-	
+
 	private ClientInfoSupplier cisSpy;
 	private String cisSpyGet = "CLIENT_INFO";
-	
+
 	private ServerInfoSupplier sisSpy;
 	private String sisSpyGet = "SERVER_INFO";
-	
+
 	@Before
 	public void buildSupplierSpies() {
-		etlsSpy = Mockito.spy(new EventTypeLogSupplier(Logger.EVENT_UNSPECIFIED));
-		cisSpy = Mockito.spy(new ClientInfoSupplier());
-		sisSpy = Mockito.spy(new ServerInfoSupplier(testName.getMethodName()));
-		
-		Mockito.when(etlsSpy.get()).thenReturn(etlsSpyGet);
-		Mockito.when(cisSpy.get()).thenReturn(cisSpyGet);
-		Mockito.when(sisSpy.get()).thenReturn(sisSpyGet);
+		etlsSpy = spy(new EventTypeLogSupplier(Logger.EVENT_UNSPECIFIED));
+		cisSpy = spy(new ClientInfoSupplier());
+		sisSpy = spy(new ServerInfoSupplier(testName.getMethodName()));
+
+		when(etlsSpy.get()).thenReturn(etlsSpyGet);
+		when(cisSpy.get()).thenReturn(cisSpyGet);
+		when(sisSpy.get()).thenReturn(sisSpyGet);
 	}
-	
+
 	@Test
 	public void verifyDelegatePassthroughCreation() throws Exception {
 		ArgumentCaptor<EventType> eventTypeCapture = ArgumentCaptor.forClass(EventType.class);
 		ArgumentCaptor<String> logNameCapture = ArgumentCaptor.forClass(String.class);
-		 PowerMockito.whenNew(EventTypeLogSupplier.class).withArguments(eventTypeCapture.capture()).thenReturn(etlsSpy);
-		 PowerMockito.whenNew(ClientInfoSupplier.class).withNoArguments().thenReturn(cisSpy);
-		 PowerMockito.whenNew(ServerInfoSupplier.class).withArguments(logNameCapture.capture()).thenReturn(sisSpy);
+		whenNew(EventTypeLogSupplier.class).withArguments(eventTypeCapture.capture()).thenReturn(etlsSpy);
+		whenNew(ClientInfoSupplier.class).withNoArguments().thenReturn(cisSpy);
+		whenNew(ServerInfoSupplier.class).withArguments(logNameCapture.capture()).thenReturn(sisSpy);
 
-		 LogPrefixAppender lpa = new LogPrefixAppender(true, true, true, testName.getMethodName()+"-APPLICATION");
-		 String result = lpa.appendTo( testName.getMethodName()+"-LOGGER", Logger.EVENT_UNSPECIFIED,  testName.getMethodName()+"-MESSAGE");
-		 
-		 //Based on the forced returns in the before block
-		 Assert.assertEquals("[EVENT_TYPE CLIENT_INFO -> SERVER_INFO] "+ testName.getMethodName()+"-MESSAGE", result);
-	     
-		 Assert.assertEquals(Logger.EVENT_UNSPECIFIED, eventTypeCapture.getValue());
-		 Assert.assertEquals(testName.getMethodName()+"-LOGGER",logNameCapture.getValue());
-		 
-		 Mockito.verify(etlsSpy, Mockito.times(1)).get();
-		 Mockito.verify(cisSpy, Mockito.times(1)).get();
-		 Mockito.verify(sisSpy, Mockito.times(1)).get();
-		 
-		 Mockito.verify(cisSpy, Mockito.times(1)).setLogUserInfo(true);
-		 Mockito.verify(sisSpy, Mockito.times(1)).setLogServerIp(true);
-		 Mockito.verify(sisSpy, Mockito.times(1)).setLogApplicationName(true, testName.getMethodName()+"-APPLICATION");
-		 
-		 Mockito.verifyNoMoreInteractions(etlsSpy, cisSpy,sisSpy);
+		LogPrefixAppender lpa = new LogPrefixAppender(true, true, true, testName.getMethodName() + "-APPLICATION");
+		String result = lpa.appendTo(testName.getMethodName() + "-LOGGER", Logger.EVENT_UNSPECIFIED,
+				testName.getMethodName() + "-MESSAGE");
+
+		// Based on the forced returns in the before block
+		assertEquals("[EVENT_TYPE CLIENT_INFO -> SERVER_INFO] " + testName.getMethodName() + "-MESSAGE", result);
+
+		assertEquals(Logger.EVENT_UNSPECIFIED, eventTypeCapture.getValue());
+		assertEquals(testName.getMethodName() + "-LOGGER", logNameCapture.getValue());
+
+		verify(etlsSpy, times(1)).get();
+		verify(cisSpy, times(1)).get();
+		verify(sisSpy, times(1)).get();
+
+		verify(cisSpy, times(1)).setLogUserInfo(true);
+		verify(sisSpy, times(1)).setLogServerIp(true);
+		verify(sisSpy, times(1)).setLogApplicationName(true, testName.getMethodName() + "-APPLICATION");
+
+		verifyNoMoreInteractions(etlsSpy, cisSpy, sisSpy);
 	}
 
 	@Test
 	public void verifyDelegatePassthroughCreation2() throws Exception {
 		ArgumentCaptor<EventType> eventTypeCapture = ArgumentCaptor.forClass(EventType.class);
 		ArgumentCaptor<String> logNameCapture = ArgumentCaptor.forClass(String.class);
-		 PowerMockito.whenNew(EventTypeLogSupplier.class).withArguments(eventTypeCapture.capture()).thenReturn(etlsSpy);
-		 PowerMockito.whenNew(ClientInfoSupplier.class).withNoArguments().thenReturn(cisSpy);
-		 PowerMockito.whenNew(ServerInfoSupplier.class).withArguments(logNameCapture.capture()).thenReturn(sisSpy);
+		whenNew(EventTypeLogSupplier.class).withArguments(eventTypeCapture.capture()).thenReturn(etlsSpy);
+		whenNew(ClientInfoSupplier.class).withNoArguments().thenReturn(cisSpy);
+		whenNew(ServerInfoSupplier.class).withArguments(logNameCapture.capture()).thenReturn(sisSpy);
 
-		 LogPrefixAppender lpa = new LogPrefixAppender(false,false,false ,null);
-		 String result = lpa.appendTo( testName.getMethodName()+"-LOGGER", Logger.EVENT_UNSPECIFIED,  testName.getMethodName()+"-MESSAGE");
-		 
-		 //Based on the forced returns in the before block
-		 Assert.assertEquals("[EVENT_TYPE CLIENT_INFO -> SERVER_INFO] "+ testName.getMethodName()+"-MESSAGE", result);
-	     
-		 Assert.assertEquals(Logger.EVENT_UNSPECIFIED, eventTypeCapture.getValue());
-		 Assert.assertEquals(testName.getMethodName()+"-LOGGER",logNameCapture.getValue());
-		 
-		 Mockito.verify(etlsSpy, Mockito.times(1)).get();
-		 Mockito.verify(cisSpy, Mockito.times(1)).get();
-		 Mockito.verify(sisSpy, Mockito.times(1)).get();
-		 
-		 Mockito.verify(cisSpy, Mockito.times(1)).setLogUserInfo(false);
-		 Mockito.verify(sisSpy, Mockito.times(1)).setLogServerIp(false);
-		 Mockito.verify(sisSpy, Mockito.times(1)).setLogApplicationName(false, null);
-		 
-		 Mockito.verifyNoMoreInteractions(etlsSpy, cisSpy,sisSpy);
+		LogPrefixAppender lpa = new LogPrefixAppender(false, false, false, null);
+		String result = lpa.appendTo(testName.getMethodName() + "-LOGGER", Logger.EVENT_UNSPECIFIED,
+				testName.getMethodName() + "-MESSAGE");
+
+		// Based on the forced returns in the before block
+		assertEquals("[EVENT_TYPE CLIENT_INFO -> SERVER_INFO] " + testName.getMethodName() + "-MESSAGE", result);
+
+		assertEquals(Logger.EVENT_UNSPECIFIED, eventTypeCapture.getValue());
+		assertEquals(testName.getMethodName() + "-LOGGER", logNameCapture.getValue());
+
+		verify(etlsSpy, times(1)).get();
+		verify(cisSpy, times(1)).get();
+		verify(sisSpy, times(1)).get();
+
+		verify(cisSpy, times(1)).setLogUserInfo(false);
+		verify(sisSpy, times(1)).setLogServerIp(false);
+		verify(sisSpy, times(1)).setLogApplicationName(false, null);
+
+		verifyNoMoreInteractions(etlsSpy, cisSpy, sisSpy);
 	}
 
 }

--- a/src/test/java/org/owasp/esapi/logging/appender/LogPrefixAppenderTest.java
+++ b/src/test/java/org/owasp/esapi/logging/appender/LogPrefixAppenderTest.java
@@ -1,0 +1,100 @@
+package org.owasp.esapi.logging.appender;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.owasp.esapi.Logger;
+import org.owasp.esapi.Logger.EventType;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import org.junit.Assert;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest (LogPrefixAppender.class)
+public class LogPrefixAppenderTest {
+	@Rule
+    public TestName testName = new TestName();
+
+	private EventTypeLogSupplier etlsSpy;
+	private String etlsSpyGet = "EVENT_TYPE";
+	
+	private ClientInfoSupplier cisSpy;
+	private String cisSpyGet = "CLIENT_INFO";
+	
+	private ServerInfoSupplier sisSpy;
+	private String sisSpyGet = "SERVER_INFO";
+	
+	@Before
+	public void buildSupplierSpies() {
+		etlsSpy = Mockito.spy(new EventTypeLogSupplier(Logger.EVENT_UNSPECIFIED));
+		cisSpy = Mockito.spy(new ClientInfoSupplier());
+		sisSpy = Mockito.spy(new ServerInfoSupplier(testName.getMethodName()));
+		
+		Mockito.when(etlsSpy.get()).thenReturn(etlsSpyGet);
+		Mockito.when(cisSpy.get()).thenReturn(cisSpyGet);
+		Mockito.when(sisSpy.get()).thenReturn(sisSpyGet);
+	}
+	
+	@Test
+	public void verifyDelegatePassthroughCreation() throws Exception {
+		ArgumentCaptor<EventType> eventTypeCapture = ArgumentCaptor.forClass(EventType.class);
+		ArgumentCaptor<String> logNameCapture = ArgumentCaptor.forClass(String.class);
+		 PowerMockito.whenNew(EventTypeLogSupplier.class).withArguments(eventTypeCapture.capture()).thenReturn(etlsSpy);
+		 PowerMockito.whenNew(ClientInfoSupplier.class).withNoArguments().thenReturn(cisSpy);
+		 PowerMockito.whenNew(ServerInfoSupplier.class).withArguments(logNameCapture.capture()).thenReturn(sisSpy);
+
+		 LogPrefixAppender lpa = new LogPrefixAppender(true, true, true, testName.getMethodName()+"-APPLICATION");
+		 String result = lpa.appendTo( testName.getMethodName()+"-LOGGER", Logger.EVENT_UNSPECIFIED,  testName.getMethodName()+"-MESSAGE");
+		 
+		 //Based on the forced returns in the before block
+		 Assert.assertEquals("[EVENT_TYPE CLIENT_INFO -> SERVER_INFO] "+ testName.getMethodName()+"-MESSAGE", result);
+	     
+		 Assert.assertEquals(Logger.EVENT_UNSPECIFIED, eventTypeCapture.getValue());
+		 Assert.assertEquals(testName.getMethodName()+"-LOGGER",logNameCapture.getValue());
+		 
+		 Mockito.verify(etlsSpy, Mockito.times(1)).get();
+		 Mockito.verify(cisSpy, Mockito.times(1)).get();
+		 Mockito.verify(sisSpy, Mockito.times(1)).get();
+		 
+		 Mockito.verify(cisSpy, Mockito.times(1)).setLogUserInfo(true);
+		 Mockito.verify(sisSpy, Mockito.times(1)).setLogServerIp(true);
+		 Mockito.verify(sisSpy, Mockito.times(1)).setLogApplicationName(true, testName.getMethodName()+"-APPLICATION");
+		 
+		 Mockito.verifyNoMoreInteractions(etlsSpy, cisSpy,sisSpy);
+	}
+
+	@Test
+	public void verifyDelegatePassthroughCreation2() throws Exception {
+		ArgumentCaptor<EventType> eventTypeCapture = ArgumentCaptor.forClass(EventType.class);
+		ArgumentCaptor<String> logNameCapture = ArgumentCaptor.forClass(String.class);
+		 PowerMockito.whenNew(EventTypeLogSupplier.class).withArguments(eventTypeCapture.capture()).thenReturn(etlsSpy);
+		 PowerMockito.whenNew(ClientInfoSupplier.class).withNoArguments().thenReturn(cisSpy);
+		 PowerMockito.whenNew(ServerInfoSupplier.class).withArguments(logNameCapture.capture()).thenReturn(sisSpy);
+
+		 LogPrefixAppender lpa = new LogPrefixAppender(false,false,false ,null);
+		 String result = lpa.appendTo( testName.getMethodName()+"-LOGGER", Logger.EVENT_UNSPECIFIED,  testName.getMethodName()+"-MESSAGE");
+		 
+		 //Based on the forced returns in the before block
+		 Assert.assertEquals("[EVENT_TYPE CLIENT_INFO -> SERVER_INFO] "+ testName.getMethodName()+"-MESSAGE", result);
+	     
+		 Assert.assertEquals(Logger.EVENT_UNSPECIFIED, eventTypeCapture.getValue());
+		 Assert.assertEquals(testName.getMethodName()+"-LOGGER",logNameCapture.getValue());
+		 
+		 Mockito.verify(etlsSpy, Mockito.times(1)).get();
+		 Mockito.verify(cisSpy, Mockito.times(1)).get();
+		 Mockito.verify(sisSpy, Mockito.times(1)).get();
+		 
+		 Mockito.verify(cisSpy, Mockito.times(1)).setLogUserInfo(false);
+		 Mockito.verify(sisSpy, Mockito.times(1)).setLogServerIp(false);
+		 Mockito.verify(sisSpy, Mockito.times(1)).setLogApplicationName(false, null);
+		 
+		 Mockito.verifyNoMoreInteractions(etlsSpy, cisSpy,sisSpy);
+	}
+
+}

--- a/src/test/java/org/owasp/esapi/logging/appender/ServerInfoSupplierTest.java
+++ b/src/test/java/org/owasp/esapi/logging/appender/ServerInfoSupplierTest.java
@@ -1,5 +1,10 @@
 package org.owasp.esapi.logging.appender;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
 import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Before;
@@ -7,83 +12,84 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.owasp.esapi.ESAPI;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ESAPI.class})
+@PrepareForTest({ ESAPI.class })
 public class ServerInfoSupplierTest {
 	@Rule
-    public TestName testName = new TestName();
-	
+	public TestName testName = new TestName();
+
 	private HttpServletRequest request;
+
 	@Before
 	public void buildStaticMocks() throws Exception {
-		request = Mockito.mock(HttpServletRequest.class);
-		 PowerMockito.mockStatic(ESAPI.class);
-	     PowerMockito.when(ESAPI.class, "currentRequest").thenReturn(request);
+		request = mock(HttpServletRequest.class);
+		mockStatic(ESAPI.class);
+		when(ESAPI.class, "currentRequest").thenReturn(request);
 	}
-	
+
 	@Test
 	public void verifyFullOutput() {
-		Mockito.when(request.getLocalAddr()).thenReturn("LOCAL_ADDR");
-		Mockito.when(request.getLocalPort()).thenReturn(99999);
-		
+		when(request.getLocalAddr()).thenReturn("LOCAL_ADDR");
+		when(request.getLocalPort()).thenReturn(99999);
+
 		ServerInfoSupplier sis = new ServerInfoSupplier(testName.getMethodName());
-		sis.setLogApplicationName(true, testName.getMethodName()+"-APPLICATION");
+		sis.setLogApplicationName(true, testName.getMethodName() + "-APPLICATION");
 		sis.setLogServerIp(true);
-		
+
 		String result = sis.get();
-		org.junit.Assert.assertEquals("LOCAL_ADDR:99999/"+testName.getMethodName()+"-APPLICATION/"+testName.getMethodName(), result);
+		assertEquals("LOCAL_ADDR:99999/" + testName.getMethodName() + "-APPLICATION/" + testName.getMethodName(),
+				result);
 	}
-	
+
 	@Test
 	public void verifyOutputNullRequest() throws Exception {
-		  PowerMockito.when(ESAPI.class, "currentRequest").thenReturn(null);
+		when(ESAPI.class, "currentRequest").thenReturn(null);
 		ServerInfoSupplier sis = new ServerInfoSupplier(testName.getMethodName());
-		sis.setLogApplicationName(true, testName.getMethodName()+"-APPLICATION");
+		sis.setLogApplicationName(true, testName.getMethodName() + "-APPLICATION");
 		sis.setLogServerIp(true);
-		
+
 		String result = sis.get();
-		org.junit.Assert.assertEquals("/"+testName.getMethodName()+"-APPLICATION/"+testName.getMethodName(), result);
+		assertEquals("/" + testName.getMethodName() + "-APPLICATION/" + testName.getMethodName(), result);
 	}
-	
+
 	@Test
 	public void verifyOutputNoAppName() {
-		Mockito.when(request.getLocalAddr()).thenReturn("LOCAL_ADDR");
-		Mockito.when(request.getLocalPort()).thenReturn(99999);
-		
+		when(request.getLocalAddr()).thenReturn("LOCAL_ADDR");
+		when(request.getLocalPort()).thenReturn(99999);
+
 		ServerInfoSupplier sis = new ServerInfoSupplier(testName.getMethodName());
 		sis.setLogApplicationName(false, null);
 		sis.setLogServerIp(true);
-		
+
 		String result = sis.get();
-		org.junit.Assert.assertEquals("LOCAL_ADDR:99999/"+testName.getMethodName(), result);
+		assertEquals("LOCAL_ADDR:99999/" + testName.getMethodName(), result);
 	}
-	
+
 	@Test
 	public void verifyOutputNullAppName() {
-		Mockito.when(request.getLocalAddr()).thenReturn("LOCAL_ADDR");
-		Mockito.when(request.getLocalPort()).thenReturn(99999);
-		
+		when(request.getLocalAddr()).thenReturn("LOCAL_ADDR");
+		when(request.getLocalPort()).thenReturn(99999);
+
 		ServerInfoSupplier sis = new ServerInfoSupplier(testName.getMethodName());
 		sis.setLogApplicationName(true, null);
 		sis.setLogServerIp(true);
-		
+
 		String result = sis.get();
-		org.junit.Assert.assertEquals("LOCAL_ADDR:99999/null/"+testName.getMethodName(), result);
+		assertEquals("LOCAL_ADDR:99999/null/" + testName.getMethodName(), result);
 	}
+
 	@Test
 	public void verifyOutputNoServerIp() {
 		ServerInfoSupplier sis = new ServerInfoSupplier(testName.getMethodName());
-		sis.setLogApplicationName(true, testName.getMethodName()+"-APPLICATION");
+		sis.setLogApplicationName(true, testName.getMethodName() + "-APPLICATION");
 		sis.setLogServerIp(false);
-		
+
 		String result = sis.get();
-		org.junit.Assert.assertEquals("/"+testName.getMethodName()+"-APPLICATION/"+testName.getMethodName(), result);
+		assertEquals("/" + testName.getMethodName() + "-APPLICATION/" + testName.getMethodName(), result);
 	}
-	
+
 }

--- a/src/test/java/org/owasp/esapi/logging/appender/ServerInfoSupplierTest.java
+++ b/src/test/java/org/owasp/esapi/logging/appender/ServerInfoSupplierTest.java
@@ -1,0 +1,89 @@
+package org.owasp.esapi.logging.appender;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.owasp.esapi.ESAPI;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ESAPI.class})
+public class ServerInfoSupplierTest {
+	@Rule
+    public TestName testName = new TestName();
+	
+	private HttpServletRequest request;
+	@Before
+	public void buildStaticMocks() throws Exception {
+		request = Mockito.mock(HttpServletRequest.class);
+		 PowerMockito.mockStatic(ESAPI.class);
+	     PowerMockito.when(ESAPI.class, "currentRequest").thenReturn(request);
+	}
+	
+	@Test
+	public void verifyFullOutput() {
+		Mockito.when(request.getLocalAddr()).thenReturn("LOCAL_ADDR");
+		Mockito.when(request.getLocalPort()).thenReturn(99999);
+		
+		ServerInfoSupplier sis = new ServerInfoSupplier(testName.getMethodName());
+		sis.setLogApplicationName(true, testName.getMethodName()+"-APPLICATION");
+		sis.setLogServerIp(true);
+		
+		String result = sis.get();
+		org.junit.Assert.assertEquals("LOCAL_ADDR:99999/"+testName.getMethodName()+"-APPLICATION/"+testName.getMethodName(), result);
+	}
+	
+	@Test
+	public void verifyOutputNullRequest() throws Exception {
+		  PowerMockito.when(ESAPI.class, "currentRequest").thenReturn(null);
+		ServerInfoSupplier sis = new ServerInfoSupplier(testName.getMethodName());
+		sis.setLogApplicationName(true, testName.getMethodName()+"-APPLICATION");
+		sis.setLogServerIp(true);
+		
+		String result = sis.get();
+		org.junit.Assert.assertEquals("/"+testName.getMethodName()+"-APPLICATION/"+testName.getMethodName(), result);
+	}
+	
+	@Test
+	public void verifyOutputNoAppName() {
+		Mockito.when(request.getLocalAddr()).thenReturn("LOCAL_ADDR");
+		Mockito.when(request.getLocalPort()).thenReturn(99999);
+		
+		ServerInfoSupplier sis = new ServerInfoSupplier(testName.getMethodName());
+		sis.setLogApplicationName(false, null);
+		sis.setLogServerIp(true);
+		
+		String result = sis.get();
+		org.junit.Assert.assertEquals("LOCAL_ADDR:99999/"+testName.getMethodName(), result);
+	}
+	
+	@Test
+	public void verifyOutputNullAppName() {
+		Mockito.when(request.getLocalAddr()).thenReturn("LOCAL_ADDR");
+		Mockito.when(request.getLocalPort()).thenReturn(99999);
+		
+		ServerInfoSupplier sis = new ServerInfoSupplier(testName.getMethodName());
+		sis.setLogApplicationName(true, null);
+		sis.setLogServerIp(true);
+		
+		String result = sis.get();
+		org.junit.Assert.assertEquals("LOCAL_ADDR:99999/null/"+testName.getMethodName(), result);
+	}
+	@Test
+	public void verifyOutputNoServerIp() {
+		ServerInfoSupplier sis = new ServerInfoSupplier(testName.getMethodName());
+		sis.setLogApplicationName(true, testName.getMethodName()+"-APPLICATION");
+		sis.setLogServerIp(false);
+		
+		String result = sis.get();
+		org.junit.Assert.assertEquals("/"+testName.getMethodName()+"-APPLICATION/"+testName.getMethodName(), result);
+	}
+	
+}

--- a/src/test/java/org/owasp/esapi/logging/slf4j/Slf4JLogFactoryTest.java
+++ b/src/test/java/org/owasp/esapi/logging/slf4j/Slf4JLogFactoryTest.java
@@ -17,10 +17,14 @@ package org.owasp.esapi.logging.slf4j;
 import java.util.List;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.owasp.esapi.Logger;
+import org.owasp.esapi.logging.appender.LogAppender;
+import org.owasp.esapi.logging.appender.LogPrefixAppender;
 import org.owasp.esapi.logging.cleaning.CodecLogScrubber;
 import org.owasp.esapi.logging.cleaning.CompositeLogScrubber;
 import org.owasp.esapi.logging.cleaning.LogScrubber;
@@ -32,6 +36,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest (Slf4JLogFactory.class)
 public class Slf4JLogFactoryTest {
+	@Rule
+    public TestName testName = new TestName();
+	
     @Test
     public void testCreateLoggerByString() {
         Logger logger = new Slf4JLogFactory().getLogger("test");
@@ -69,4 +76,31 @@ public class Slf4JLogFactoryTest {
         Assert.assertEquals(1, scrubbers.size());
         Assert.assertTrue(scrubbers.get(0) instanceof NewlineLogScrubber);
     }
+    
+    /**
+	 * At this time there are no special considerations or handling for the appender
+	 * creation in this scope. It is expected that the arguments to the internal
+	 * creation method are passed directly to the constructor of the
+	 * LogPrefixAppender with no mutation or additional validation.
+	 */
+    @Test
+    public void checkPassthroughAppenderConstruct() throws Exception {
+    	LogPrefixAppender stubAppender = new LogPrefixAppender(true, true, true, "");
+    	ArgumentCaptor<Boolean> clientInfoCapture = ArgumentCaptor.forClass(Boolean.class);
+    	ArgumentCaptor<Boolean> serverInfoCapture = ArgumentCaptor.forClass(Boolean.class);
+    	ArgumentCaptor<Boolean> logAppNameCapture = ArgumentCaptor.forClass(Boolean.class);
+    	ArgumentCaptor<String> appNameCapture = ArgumentCaptor.forClass(String.class);
+    	
+    	PowerMockito.whenNew(LogPrefixAppender.class).withArguments(clientInfoCapture.capture(), serverInfoCapture.capture(), logAppNameCapture.capture(), appNameCapture.capture()).thenReturn(stubAppender);
+    	
+    	LogAppender appender = Slf4JLogFactory.createLogAppender(true, false, true, testName.getMethodName());
+    	
+    	Assert.assertEquals(stubAppender, appender);
+    	Assert.assertTrue(clientInfoCapture.getValue());
+    	Assert.assertFalse(serverInfoCapture.getValue());
+    	Assert.assertTrue(logAppNameCapture.getValue());
+    	Assert.assertEquals(testName.getMethodName(), appNameCapture.getValue());    	
+    }
+    
+   
 }


### PR DESCRIPTION
Should resolve #530 
- adds a new API for log appending to the esapi.logging packages
  - Default appender is composed of EventType, ClientInfo, and ServerInfo
    - Each component of the log content is isolated to a small, testable unit.
- SLF4J implementation has been updated to create and use the new log appender to prefix the desired message.
- tests updated and passing
  - Tests identified in issue #521 are not passing, but all others are functional 
- All property configurations are maintained in the Slf4JLogFactory implementation.
  - Consideration for future option to suppress user content is integrated, and only needs to be extracted at runtime.