### PR TITLE
Issue 536

### DIFF
--- a/src/main/java/org/owasp/esapi/filters/SecurityWrapperResponse.java
+++ b/src/main/java/org/owasp/esapi/filters/SecurityWrapperResponse.java
@@ -483,15 +483,28 @@ public class SecurityWrapperResponse extends HttpServletResponseWrapper implemen
      * @param value
      */
     public void setHeader(String name, String value) {
+        SecurityConfiguration sc = ESAPI.securityConfiguration();
+        String strippedName = StringUtilities.stripControls(name);
+        String strippedValue = StringUtilities.stripControls(value);
+        String safeName = null;
+        String safeValue = null;
         try {
-            String strippedName = StringUtilities.stripControls(name);
-            String strippedValue = StringUtilities.stripControls(value);
-            SecurityConfiguration sc = ESAPI.securityConfiguration();
-            String safeName = ESAPI.validator().getValidInput("setHeader", strippedName, "HTTPHeaderName", sc.getIntProp("HttpUtilities.MaxHeaderNameSize"), false);
-            String safeValue = ESAPI.validator().getValidInput("setHeader", strippedValue, "HTTPHeaderValue", sc.getIntProp("HttpUtilities.MaxHeaderValueSize"), false);
-            getHttpServletResponse().setHeader(safeName, safeValue);
+            safeName = ESAPI.validator().getValidInput("setHeader", strippedName, "HTTPHeaderName", sc.getIntProp("HttpUtilities.MaxHeaderNameSize"), false);
         } catch (ValidationException e) {
-            logger.warning(Logger.SECURITY_FAILURE, "Attempt to set invalid header denied", e);
+            logger.warning(Logger.SECURITY_FAILURE, "Attempt to set invalid header denied [HEADER_NAME]", e);
+        }
+        
+        try {
+            safeValue = ESAPI.validator().getValidInput("setHeader", strippedValue, "HTTPHeaderValue", sc.getIntProp("HttpUtilities.MaxHeaderValueSize"), false);
+        } catch (ValidationException e) {
+            logger.warning(Logger.SECURITY_FAILURE, "Attempt to set invalid header denied [HEADER_VALUE]", e);
+        }
+        
+        boolean validName = StringUtilities.notNullOrEmpty(safeName, true);
+        boolean validValue = StringUtilities.notNullOrEmpty(safeValue, true);
+        
+        if (validName && validValue) {
+            getHttpServletResponse().setHeader(safeName, safeValue);
         }
     }
 

--- a/src/main/java/org/owasp/esapi/filters/SecurityWrapperResponse.java
+++ b/src/main/java/org/owasp/esapi/filters/SecurityWrapperResponse.java
@@ -181,13 +181,13 @@ public class SecurityWrapperResponse extends HttpServletResponseWrapper implemen
         try {
             safeName = ESAPI.validator().getValidInput("addHeader", strippedName, "HTTPHeaderName", sc.getIntProp("HttpUtilities.MaxHeaderNameSize"), false);
         } catch (ValidationException e) {
-            logger.warning(Logger.SECURITY_FAILURE, "Attempt to set invalid header denied [HEADER_NAME]", e);
+            logger.warning(Logger.SECURITY_FAILURE, "Attempt to add invalid header denied [HEADER_NAME]", e);
         }
         
         try {
             safeValue = ESAPI.validator().getValidInput("addHeader", strippedValue, "HTTPHeaderValue", sc.getIntProp("HttpUtilities.MaxHeaderValueSize"), false);
         } catch (ValidationException e) {
-            logger.warning(Logger.SECURITY_FAILURE, "Attempt to set invalid header denied [HEADER_VALUE]", e);
+            logger.warning(Logger.SECURITY_FAILURE, "Attempt to add invalid header denied [HEADER_VALUE]", e);
         }
         
         boolean validName = StringUtilities.notNullOrEmpty(safeName, true);

--- a/src/main/java/org/owasp/esapi/filters/SecurityWrapperResponse.java
+++ b/src/main/java/org/owasp/esapi/filters/SecurityWrapperResponse.java
@@ -173,16 +173,28 @@ public class SecurityWrapperResponse extends HttpServletResponseWrapper implemen
      * @param value
      */
     public void addHeader(String name, String value) {
+        SecurityConfiguration sc = ESAPI.securityConfiguration();
+        String strippedName = StringUtilities.stripControls(name);
+        String strippedValue = StringUtilities.stripControls(value);
+        String safeName = null;
+        String safeValue = null;
         try {
-            // TODO: make stripping a global config
-            SecurityConfiguration sc = ESAPI.securityConfiguration();
-            String strippedName = StringUtilities.stripControls(name);
-            String strippedValue = StringUtilities.stripControls(value);
-            String safeName = ESAPI.validator().getValidInput("addHeader", strippedName, "HTTPHeaderName", sc.getIntProp("HttpUtilities.MaxHeaderNameSize"), false);
-            String safeValue = ESAPI.validator().getValidInput("addHeader", strippedValue, "HTTPHeaderValue", sc.getIntProp("HttpUtilities.MaxHeaderValueSize"), false);
-            getHttpServletResponse().addHeader(safeName, safeValue);
+            safeName = ESAPI.validator().getValidInput("addHeader", strippedName, "HTTPHeaderName", sc.getIntProp("HttpUtilities.MaxHeaderNameSize"), false);
         } catch (ValidationException e) {
-            logger.warning(Logger.SECURITY_FAILURE, "Attempt to add invalid header denied", e);
+            logger.warning(Logger.SECURITY_FAILURE, "Attempt to set invalid header denied [HEADER_NAME]", e);
+        }
+        
+        try {
+            safeValue = ESAPI.validator().getValidInput("addHeader", strippedValue, "HTTPHeaderValue", sc.getIntProp("HttpUtilities.MaxHeaderValueSize"), false);
+        } catch (ValidationException e) {
+            logger.warning(Logger.SECURITY_FAILURE, "Attempt to set invalid header denied [HEADER_VALUE]", e);
+        }
+        
+        boolean validName = StringUtilities.notNullOrEmpty(safeName, true);
+        boolean validValue = StringUtilities.notNullOrEmpty(safeValue, true);
+        
+        if (validName && validValue) {
+            getHttpServletResponse().addHeader(safeName, safeValue);
         }
     }
     

--- a/src/main/java/org/owasp/esapi/filters/SecurityWrapperResponse.java
+++ b/src/main/java/org/owasp/esapi/filters/SecurityWrapperResponse.java
@@ -181,13 +181,13 @@ public class SecurityWrapperResponse extends HttpServletResponseWrapper implemen
         try {
             safeName = ESAPI.validator().getValidInput("addHeader", strippedName, "HTTPHeaderName", sc.getIntProp("HttpUtilities.MaxHeaderNameSize"), false);
         } catch (ValidationException e) {
-            logger.warning(Logger.SECURITY_FAILURE, "Attempt to add invalid header denied [HEADER_NAME]", e);
+            logger.warning(Logger.SECURITY_FAILURE, "Attempt to add invalid header NAME denied: HTTPHeaderName:"+ name, e);
         }
         
         try {
             safeValue = ESAPI.validator().getValidInput("addHeader", strippedValue, "HTTPHeaderValue", sc.getIntProp("HttpUtilities.MaxHeaderValueSize"), false);
         } catch (ValidationException e) {
-            logger.warning(Logger.SECURITY_FAILURE, "Attempt to add invalid header denied [HEADER_VALUE]", e);
+            logger.warning(Logger.SECURITY_FAILURE, "Attempt to add invalid header VALUE denied: HTTPHeaderName:"+ name, e);
         }
         
         boolean validName = StringUtilities.notNullOrEmpty(safeName, true);
@@ -503,13 +503,13 @@ public class SecurityWrapperResponse extends HttpServletResponseWrapper implemen
         try {
             safeName = ESAPI.validator().getValidInput("setHeader", strippedName, "HTTPHeaderName", sc.getIntProp("HttpUtilities.MaxHeaderNameSize"), false);
         } catch (ValidationException e) {
-            logger.warning(Logger.SECURITY_FAILURE, "Attempt to set invalid header denied [HEADER_NAME]", e);
+            logger.warning(Logger.SECURITY_FAILURE, "Attempt to set invalid header NAME denied: HTTPHeaderName:"+ name, e);
         }
         
         try {
             safeValue = ESAPI.validator().getValidInput("setHeader", strippedValue, "HTTPHeaderValue", sc.getIntProp("HttpUtilities.MaxHeaderValueSize"), false);
         } catch (ValidationException e) {
-            logger.warning(Logger.SECURITY_FAILURE, "Attempt to set invalid header denied [HEADER_VALUE]", e);
+            logger.warning(Logger.SECURITY_FAILURE, "Attempt to set invalid header VALUE denied: HTTPHeaderName:"+ name, e);
         }
         
         boolean validName = StringUtilities.notNullOrEmpty(safeName, true);

--- a/src/test/java/org/owasp/esapi/filters/SecurityWrapperRequestTest.java
+++ b/src/test/java/org/owasp/esapi/filters/SecurityWrapperRequestTest.java
@@ -18,8 +18,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 // A hack for now; eventually, I plan to move this into a new org.owasp.esapi.PropNames class. -kww
@@ -41,7 +41,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.Logger;
-import org.owasp.esapi.Logger.EventType;
 import org.owasp.esapi.SecurityConfiguration;
 import org.owasp.esapi.Validator;
 import org.owasp.esapi.errors.ValidationException;
@@ -61,15 +60,15 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(ESAPI.class)
 public class SecurityWrapperRequestTest {
-	private static final String ESAPI_VALIDATOR_GETTER_METHOD_NAME = "validator";
-	private static final String ESAPI_GET_LOGGER_METHOD_NAME = "getLogger";
-    private static final String ESAPY_SECURITY_CONFIGURATION_GETTER_METHOD_NAME = "securityConfiguration";
-    private static final String SECURITY_CONFIGURATION_QUERY_STRING_LENGTH_KEY_NAME = "HttpUtilities.URILENGTH";
-    private static final String SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME = "HttpUtilities.httpQueryParamValueLength";
+    protected static final String ESAPI_VALIDATOR_GETTER_METHOD_NAME = "validator";
+	protected static final String ESAPI_GET_LOGGER_METHOD_NAME = "getLogger";
+	protected static final String ESAPY_SECURITY_CONFIGURATION_GETTER_METHOD_NAME = "securityConfiguration";
+    protected static final String SECURITY_CONFIGURATION_QUERY_STRING_LENGTH_KEY_NAME = "HttpUtilities.URILENGTH";
+    protected static final String SECURITY_CONFIGURATION_PARAMETER_STRING_LENGTH_KEY_NAME = "HttpUtilities.httpQueryParamValueLength";
     private static final String SECURITY_CONFIGURATION_HEADER_NAME_LENGTH_KEY_NAME = "HttpUtilities.MaxHeaderNameSize";
     private static final String SECURITY_CONFIGURATION_HEADER_VALUE_LENGTH_KEY_NAME = "HttpUtilities.MaxHeaderValueSize";
     
-    private static final int SECURITY_CONFIGURATION_TEST_LENGTH = 255;
+    protected static final int SECURITY_CONFIGURATION_TEST_LENGTH = 255;
 
     private static final String QUERY_STRING_CANONCALIZE_TYPE_KEY = "HTTPQueryString";
     private static final String PARAMETER_STRING_CANONCALIZE_TYPE_KEY = "HTTPParameterValue";

--- a/src/test/java/org/owasp/esapi/filters/SecurityWrapperResponseTest.java
+++ b/src/test/java/org/owasp/esapi/filters/SecurityWrapperResponseTest.java
@@ -40,8 +40,8 @@ public class SecurityWrapperResponseTest {
     private static final String HEADER_VALUE_CONTEXT = "HTTPHeaderValue";
     private static final String SEC_CTX_MAX_HEADER_NAME_SIZE_ATTR = "HttpUtilities.MaxHeaderNameSize";
     private static final String SEC_CTX_MAX_HEADER_VALUE_SIZE_ATTR = "HttpUtilities.MaxHeaderValueSize";
-    
-            
+
+
     @Rule
     public TestName testName = new TestName();
 
@@ -53,7 +53,7 @@ public class SecurityWrapperResponseTest {
     private SecurityConfiguration mockSecConfig;
     @Mock
     private Logger mockLogger;
-    
+
     private String goodHeaderName;
     private String goodHeaderValue;
 
@@ -74,7 +74,7 @@ public class SecurityWrapperResponseTest {
             goodHeaderValue = testName.getMethodName() + "_goodHeaderValue";
         }
     }
-    
+
     @Test
     public void testSetHeaderHappyPath() throws Exception {
         String validateNameResponse = goodHeaderName;
@@ -83,7 +83,7 @@ public class SecurityWrapperResponseTest {
                 ArgumentMatchers.eq(HEADER_NAME_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
                 ArgumentMatchers.eq(false))).thenReturn(validateNameResponse);
-      
+
         PowerMockito.when(mockValidator.getValidInput(anyString(), ArgumentMatchers.eq(goodHeaderValue),
                 ArgumentMatchers.eq(HEADER_VALUE_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
@@ -91,7 +91,7 @@ public class SecurityWrapperResponseTest {
 
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_NAME_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
-      
+
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_VALUE_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -106,7 +106,7 @@ public class SecurityWrapperResponseTest {
         verify(mockResponse, times(1)).setHeader(validateNameResponse, validateValueResponse);
         verify(mockLogger,times(0)).warning(ArgumentMatchers.any(org.owasp.esapi.Logger.EventType.class), anyString(), ArgumentMatchers.any(Exception.class));      
     }
-    
+
     @Test
     public void testSetHeaderNameNull() throws Exception {
         String validateNameResponse = null;
@@ -115,7 +115,7 @@ public class SecurityWrapperResponseTest {
                 ArgumentMatchers.eq(HEADER_NAME_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
                 ArgumentMatchers.eq(false))).thenReturn(validateNameResponse);
-      
+
         PowerMockito.when(mockValidator.getValidInput(anyString(), ArgumentMatchers.eq(goodHeaderValue),
                 ArgumentMatchers.eq(HEADER_VALUE_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
@@ -123,7 +123,7 @@ public class SecurityWrapperResponseTest {
 
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_NAME_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
-      
+
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_VALUE_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -145,7 +145,7 @@ public class SecurityWrapperResponseTest {
         verify(mockLogger, times(0)).warning(ArgumentMatchers.any(org.owasp.esapi.Logger.EventType.class),anyString(),
                 ArgumentMatchers.any(Exception.class));
     }
-    
+
     @Test
     public void testSetHeaderNameEmpty() throws Exception {
         String validateNameResponse = "     ";
@@ -154,7 +154,7 @@ public class SecurityWrapperResponseTest {
                 ArgumentMatchers.eq(HEADER_NAME_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
                 ArgumentMatchers.eq(false))).thenReturn(validateNameResponse);
-      
+
         PowerMockito.when(mockValidator.getValidInput(anyString(), ArgumentMatchers.eq(goodHeaderValue),
                 ArgumentMatchers.eq(HEADER_VALUE_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
@@ -162,7 +162,7 @@ public class SecurityWrapperResponseTest {
 
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_NAME_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
-      
+
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_VALUE_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -184,7 +184,7 @@ public class SecurityWrapperResponseTest {
         verify(mockLogger, times(0)).warning(ArgumentMatchers.any(org.owasp.esapi.Logger.EventType.class),anyString(),
                 ArgumentMatchers.any(Exception.class));
     }
-    
+
     @Test
     public void testSetHeaderNameThrowsValidationException() throws Exception {
         String validateValueResponse = goodHeaderValue;
@@ -192,7 +192,7 @@ public class SecurityWrapperResponseTest {
                 ArgumentMatchers.eq(HEADER_NAME_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
                 ArgumentMatchers.eq(false))).thenThrow(ValidationException.class);
-      
+
         PowerMockito.when(mockValidator.getValidInput(anyString(), ArgumentMatchers.eq(goodHeaderValue),
                 ArgumentMatchers.eq(HEADER_VALUE_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
@@ -200,7 +200,7 @@ public class SecurityWrapperResponseTest {
 
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_NAME_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
-      
+
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_VALUE_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -221,10 +221,10 @@ public class SecurityWrapperResponseTest {
         verify(mockResponse, times(0)).setHeader(anyString(), anyString());
 
         verify(mockLogger, times(1)).warning(ArgumentMatchers.any(org.owasp.esapi.Logger.EventType.class),
-                ArgumentMatchers.contains("Attempt to set invalid header denied [HEADER_NAME]"),
+                ArgumentMatchers.contains("Attempt to set invalid header NAME denied: HTTPHeaderName:"+ goodHeaderName),
                 ArgumentMatchers.any(Exception.class));
     }
-    
+
     @Test
     public void testSetHeaderValueNull() throws Exception {
         String validateNameResponse = goodHeaderName;
@@ -233,7 +233,7 @@ public class SecurityWrapperResponseTest {
                 ArgumentMatchers.eq(HEADER_NAME_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
                 ArgumentMatchers.eq(false))).thenReturn(validateNameResponse);
-      
+
         PowerMockito.when(mockValidator.getValidInput(anyString(), ArgumentMatchers.eq(goodHeaderValue),
                 ArgumentMatchers.eq(HEADER_VALUE_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
@@ -241,7 +241,7 @@ public class SecurityWrapperResponseTest {
 
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_NAME_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
-      
+
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_VALUE_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -263,7 +263,7 @@ public class SecurityWrapperResponseTest {
         verify(mockLogger, times(0)).warning(ArgumentMatchers.any(org.owasp.esapi.Logger.EventType.class),anyString(),
                 ArgumentMatchers.any(Exception.class)); 
     }
-    
+
     @Test
     public void testSetHeaderValueEmpty() throws Exception {
         String validateNameResponse = goodHeaderName;
@@ -272,7 +272,7 @@ public class SecurityWrapperResponseTest {
                 ArgumentMatchers.eq(HEADER_NAME_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
                 ArgumentMatchers.eq(false))).thenReturn(validateNameResponse);
-      
+
         PowerMockito.when(mockValidator.getValidInput(anyString(), ArgumentMatchers.eq(goodHeaderValue),
                 ArgumentMatchers.eq(HEADER_VALUE_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
@@ -280,7 +280,7 @@ public class SecurityWrapperResponseTest {
 
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_NAME_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
-      
+
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_VALUE_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -302,15 +302,15 @@ public class SecurityWrapperResponseTest {
         verify(mockLogger, times(0)).warning(ArgumentMatchers.any(org.owasp.esapi.Logger.EventType.class),anyString(),
                 ArgumentMatchers.any(Exception.class));   
     }
-    
+
     @Test
     public void testSetHeaderValueThrowsValidationException() throws Exception {
-         String validateNameResponse = goodHeaderName;
+        String validateNameResponse = goodHeaderName;
         PowerMockito.when(mockValidator.getValidInput(anyString(), ArgumentMatchers.eq(goodHeaderName),
                 ArgumentMatchers.eq(HEADER_NAME_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
                 ArgumentMatchers.eq(false))).thenReturn(validateNameResponse);
-      
+
         PowerMockito.when(mockValidator.getValidInput(anyString(), ArgumentMatchers.eq(goodHeaderValue),
                 ArgumentMatchers.eq(HEADER_VALUE_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
@@ -318,7 +318,7 @@ public class SecurityWrapperResponseTest {
 
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_NAME_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
-      
+
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_VALUE_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -339,10 +339,10 @@ public class SecurityWrapperResponseTest {
         verify(mockResponse, times(0)).setHeader(anyString(), anyString());
 
         verify(mockLogger, times(1)).warning(ArgumentMatchers.any(org.owasp.esapi.Logger.EventType.class),
-                ArgumentMatchers.contains("Attempt to set invalid header denied [HEADER_VALUE]"),
+                ArgumentMatchers.contains("Attempt to set invalid header VALUE denied: HTTPHeaderName:"+ goodHeaderName),
                 ArgumentMatchers.any(Exception.class));
     }
-        
+
     @Test
     public void testAddHeaderHappyPath() throws Exception {
         String validateNameResponse = goodHeaderName;
@@ -351,7 +351,7 @@ public class SecurityWrapperResponseTest {
                 ArgumentMatchers.eq(HEADER_NAME_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
                 ArgumentMatchers.eq(false))).thenReturn(validateNameResponse);
-      
+
         PowerMockito.when(mockValidator.getValidInput(anyString(), ArgumentMatchers.eq(goodHeaderValue),
                 ArgumentMatchers.eq(HEADER_VALUE_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
@@ -359,7 +359,7 @@ public class SecurityWrapperResponseTest {
 
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_NAME_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
-      
+
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_VALUE_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -374,7 +374,7 @@ public class SecurityWrapperResponseTest {
         verify(mockResponse, times(1)).addHeader(validateNameResponse, validateValueResponse);
         verify(mockLogger,times(0)).warning(ArgumentMatchers.any(org.owasp.esapi.Logger.EventType.class), anyString(), ArgumentMatchers.any(Exception.class));      
     }
-    
+
     @Test
     public void testAddHeaderNameNull() throws Exception {
         String validateNameResponse = null;
@@ -383,7 +383,7 @@ public class SecurityWrapperResponseTest {
                 ArgumentMatchers.eq(HEADER_NAME_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
                 ArgumentMatchers.eq(false))).thenReturn(validateNameResponse);
-      
+
         PowerMockito.when(mockValidator.getValidInput(anyString(), ArgumentMatchers.eq(goodHeaderValue),
                 ArgumentMatchers.eq(HEADER_VALUE_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
@@ -391,7 +391,7 @@ public class SecurityWrapperResponseTest {
 
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_NAME_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
-      
+
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_VALUE_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -413,7 +413,7 @@ public class SecurityWrapperResponseTest {
         verify(mockLogger, times(0)).warning(ArgumentMatchers.any(org.owasp.esapi.Logger.EventType.class),anyString(),
                 ArgumentMatchers.any(Exception.class));
     }
-    
+
     @Test
     public void testAddHeaderNameEmpty() throws Exception {
         String validateNameResponse = "     ";
@@ -422,7 +422,7 @@ public class SecurityWrapperResponseTest {
                 ArgumentMatchers.eq(HEADER_NAME_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
                 ArgumentMatchers.eq(false))).thenReturn(validateNameResponse);
-      
+
         PowerMockito.when(mockValidator.getValidInput(anyString(), ArgumentMatchers.eq(goodHeaderValue),
                 ArgumentMatchers.eq(HEADER_VALUE_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
@@ -430,7 +430,7 @@ public class SecurityWrapperResponseTest {
 
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_NAME_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
-      
+
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_VALUE_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -452,7 +452,7 @@ public class SecurityWrapperResponseTest {
         verify(mockLogger, times(0)).warning(ArgumentMatchers.any(org.owasp.esapi.Logger.EventType.class),anyString(),
                 ArgumentMatchers.any(Exception.class));
     }
-    
+
     @Test
     public void testAddHeaderNameThrowsValidationException() throws Exception {
         String validateValueResponse = goodHeaderValue;
@@ -460,7 +460,7 @@ public class SecurityWrapperResponseTest {
                 ArgumentMatchers.eq(HEADER_NAME_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
                 ArgumentMatchers.eq(false))).thenThrow(ValidationException.class);
-      
+
         PowerMockito.when(mockValidator.getValidInput(anyString(), ArgumentMatchers.eq(goodHeaderValue),
                 ArgumentMatchers.eq(HEADER_VALUE_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
@@ -468,7 +468,7 @@ public class SecurityWrapperResponseTest {
 
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_NAME_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
-      
+
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_VALUE_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -489,10 +489,10 @@ public class SecurityWrapperResponseTest {
         verify(mockResponse, times(0)).addHeader(anyString(), anyString());
 
         verify(mockLogger, times(1)).warning(ArgumentMatchers.any(org.owasp.esapi.Logger.EventType.class),
-                ArgumentMatchers.contains("Attempt to set invalid header denied [HEADER_NAME]"),
+                ArgumentMatchers.contains("Attempt to add invalid header NAME denied: HTTPHeaderName:"+ goodHeaderName ),
                 ArgumentMatchers.any(Exception.class));
     }
-    
+
     @Test
     public void testAddHeaderValueNull() throws Exception {
         String validateNameResponse = goodHeaderName;
@@ -501,7 +501,7 @@ public class SecurityWrapperResponseTest {
                 ArgumentMatchers.eq(HEADER_NAME_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
                 ArgumentMatchers.eq(false))).thenReturn(validateNameResponse);
-      
+
         PowerMockito.when(mockValidator.getValidInput(anyString(), ArgumentMatchers.eq(goodHeaderValue),
                 ArgumentMatchers.eq(HEADER_VALUE_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
@@ -509,7 +509,7 @@ public class SecurityWrapperResponseTest {
 
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_NAME_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
-      
+
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_VALUE_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -531,7 +531,7 @@ public class SecurityWrapperResponseTest {
         verify(mockLogger, times(0)).warning(ArgumentMatchers.any(org.owasp.esapi.Logger.EventType.class),anyString(),
                 ArgumentMatchers.any(Exception.class)); 
     }
-    
+
     @Test
     public void testAddHeaderValueEmpty() throws Exception {
         String validateNameResponse = goodHeaderName;
@@ -540,7 +540,7 @@ public class SecurityWrapperResponseTest {
                 ArgumentMatchers.eq(HEADER_NAME_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
                 ArgumentMatchers.eq(false))).thenReturn(validateNameResponse);
-      
+
         PowerMockito.when(mockValidator.getValidInput(anyString(), ArgumentMatchers.eq(goodHeaderValue),
                 ArgumentMatchers.eq(HEADER_VALUE_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
@@ -548,7 +548,7 @@ public class SecurityWrapperResponseTest {
 
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_NAME_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
-      
+
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_VALUE_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -570,15 +570,15 @@ public class SecurityWrapperResponseTest {
         verify(mockLogger, times(0)).warning(ArgumentMatchers.any(org.owasp.esapi.Logger.EventType.class),anyString(),
                 ArgumentMatchers.any(Exception.class));   
     }
-    
+
     @Test
     public void testAddHeaderValueThrowsValidationException() throws Exception {
-         String validateNameResponse = goodHeaderName;
+        String validateNameResponse = goodHeaderName;
         PowerMockito.when(mockValidator.getValidInput(anyString(), ArgumentMatchers.eq(goodHeaderName),
                 ArgumentMatchers.eq(HEADER_NAME_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
                 ArgumentMatchers.eq(false))).thenReturn(validateNameResponse);
-      
+
         PowerMockito.when(mockValidator.getValidInput(anyString(), ArgumentMatchers.eq(goodHeaderValue),
                 ArgumentMatchers.eq(HEADER_VALUE_CONTEXT),
                 ArgumentMatchers.eq(SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH),
@@ -586,7 +586,7 @@ public class SecurityWrapperResponseTest {
 
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_NAME_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
-      
+
         PowerMockito.when(mockSecConfig.getIntProp(SEC_CTX_MAX_HEADER_VALUE_SIZE_ATTR)).thenReturn(
                 SecurityWrapperRequestTest.SECURITY_CONFIGURATION_TEST_LENGTH);
 
@@ -607,10 +607,10 @@ public class SecurityWrapperResponseTest {
         verify(mockResponse, times(0)).addHeader(anyString(), anyString());
 
         verify(mockLogger, times(1)).warning(ArgumentMatchers.any(org.owasp.esapi.Logger.EventType.class),
-                ArgumentMatchers.contains("Attempt to set invalid header denied [HEADER_VALUE]"),
+                ArgumentMatchers.contains("Attempt to add invalid header VALUE denied: HTTPHeaderName:"+ goodHeaderName),
                 ArgumentMatchers.any(Exception.class));
     }
-    
+
     @Test
     public void testAddRefererHeader(){
         HttpServletResponse servResp = mock(HttpServletResponse.class);
@@ -618,7 +618,7 @@ public class SecurityWrapperResponseTest {
         resp.addReferer("http://127.0.0.1:3000/campaigns?goal=all&section=active&sort-by=-id&status=Draft%2CLaunched");
         verify(servResp, times(1)).addHeader("referer", "");
     }
-    
+
     @Test
     public void testAddDateHeader(){
         HttpServletResponse servResp = mock(HttpServletResponse.class);
@@ -627,7 +627,7 @@ public class SecurityWrapperResponseTest {
         resp.addDateHeader("Foo", currentTime);
         verify(servResp, times(1)).addDateHeader("Foo", currentTime);
     }
-    
+
     @Test
     public void testSetDateHeader(){
         HttpServletResponse servResp = mock(HttpServletResponse.class);
@@ -636,7 +636,7 @@ public class SecurityWrapperResponseTest {
         resp.setDateHeader("Foo", currentTime);
         verify(servResp, times(1)).setDateHeader("Foo", currentTime);
     }
-    
+
     @Test
     public void testSetInvalidDateHeader(){
         HttpServletResponse servResp = mock(HttpServletResponse.class);
@@ -645,7 +645,7 @@ public class SecurityWrapperResponseTest {
         resp.setDateHeader("<scr", currentTime);
         verify(servResp, times(0)).setDateHeader("<scr", currentTime);
     }
-  
+
     @Test
     public void testSetInvalidHeader(){
         HttpServletResponse servResp = mock(HttpServletResponse.class);
@@ -653,7 +653,7 @@ public class SecurityWrapperResponseTest {
         resp.setHeader("foo", "<script>alert</script>");
         verify(servResp, times(0)).setHeader("foo", "<script>alert</script>");
     }
-    
+
     @Test
     public void testInvalidDateHeader(){
         HttpServletResponse servResp = mock(HttpServletResponse.class);
@@ -662,7 +662,7 @@ public class SecurityWrapperResponseTest {
         resp.addDateHeader("Foo\\r\\n", currentTime);
         verify(servResp, times(0)).addDateHeader("Foo", currentTime);
     }
-    
+
     @Test
     public void testAddHeaderInvalidValueLength(){
         //refactor this to use a spy. 
@@ -673,7 +673,7 @@ public class SecurityWrapperResponseTest {
         resp.addHeader("Foo", TestUtils.generateStringOfLength(4097));
         verify(servResp, times(0)).addHeader("Foo", "bar");
     }
-    
+
     @Test
     public void testAddHeaderInvalidKeyLength(){
         HttpServletResponse servResp = mock(HttpServletResponse.class);
@@ -681,7 +681,7 @@ public class SecurityWrapperResponseTest {
         resp.addHeader(TestUtils.generateStringOfLength(257), "bar");
         verify(servResp, times(0)).addHeader("Foo", "bar");
     }
-    
+
     @Test
     public void testAddIntHeader(){
         HttpServletResponse servResp = mock(HttpServletResponse.class);
@@ -689,7 +689,7 @@ public class SecurityWrapperResponseTest {
         resp.addIntHeader("aaaa", 4);
         verify(servResp, times(1)).addIntHeader("aaaa", 4);
     }
-    
+
     @Test
     public void testAddInvalidIntHeader(){
         HttpServletResponse servResp = mock(HttpServletResponse.class);
@@ -697,7 +697,7 @@ public class SecurityWrapperResponseTest {
         resp.addIntHeader(TestUtils.generateStringOfLength(257), Integer.MIN_VALUE);
         verify(servResp, times(0)).addIntHeader(TestUtils.generateStringOfLength(257), Integer.MIN_VALUE);
     }
-    
+
     @Test
     public void testContainsHeader(){
         HttpServletResponse servResp = new MockHttpServletResponse();
@@ -708,7 +708,7 @@ public class SecurityWrapperResponseTest {
         verify(servResp, times(1)).addIntHeader("aaaa", Integer.MIN_VALUE);
         assertEquals(true, servResp.containsHeader("aaaa"));
     }
-    
+
     @Test
     public void testAddValidCookie(){
         HttpServletResponse servResp = new MockHttpServletResponse();
@@ -719,7 +719,7 @@ public class SecurityWrapperResponseTest {
         cookie.setMaxAge(5000);
         Mockito.doCallRealMethod().when(spyResp).addCookie(cookie);
         spyResp.addCookie(cookie);
-        
+
         /*
          * We're indirectly testing our class.  Since it ultimately
          * delegates to HttpServletResponse.addHeader, we're actually 
@@ -729,7 +729,7 @@ public class SecurityWrapperResponseTest {
          */
         verify(servResp, times(1)).addHeader("Set-Cookie", "Foo=aaaaaaaaaa; Max-Age=5000; Secure; HttpOnly");
     }
-    
+
     @Test
     public void testAddValidCookieWithDomain(){
         HttpServletResponse servResp = new MockHttpServletResponse();
@@ -743,7 +743,7 @@ public class SecurityWrapperResponseTest {
         spyResp.addCookie(cookie);
         verify(servResp, times(1)).addHeader("Set-Cookie", "Foo=aaaaaaaaaa; Domain=evil.com; Secure; HttpOnly");
     }
-    
+
     @Test
     public void testAddValidCookieWithPath(){
         HttpServletResponse servResp = new MockHttpServletResponse();
@@ -757,7 +757,7 @@ public class SecurityWrapperResponseTest {
         spyResp.addCookie(cookie);
         verify(servResp, times(1)).addHeader("Set-Cookie", "Foo=aaaaaaaaaa; Domain=evil.com; Path=/foo/bar; Secure; HttpOnly");
     }
-    
+
     @Test
     public void testAddInValidCookie(){
         HttpServletResponse servResp = new MockHttpServletResponse();
@@ -766,11 +766,11 @@ public class SecurityWrapperResponseTest {
         SecurityWrapperResponse spyResp = spy(resp);
         Cookie cookie = new Cookie("Foo", TestUtils.generateStringOfLength(5000));
         Mockito.doCallRealMethod().when(spyResp).addCookie(cookie);
-        
+
         spyResp.addCookie(cookie);
         verify(servResp, times(0)).addHeader("Set-Cookie", "Foo=" + TestUtils.generateStringOfLength(5000) + "; Secure; HttpOnly");
     }
-    
+
     @Test
     public void testSendError() throws Exception{
         HttpServletResponse servResp = new MockHttpServletResponse();
@@ -779,10 +779,10 @@ public class SecurityWrapperResponseTest {
         SecurityWrapperResponse spyResp = spy(resp);
         Mockito.doCallRealMethod().when(spyResp).sendError(200);
         spyResp.sendError(200);
-        
+
         verify(servResp, times(1)).sendError(200, "HTTP error code: 200");;
     }
-    
+
     @Test
     public void testSendStatus() throws Exception{
         HttpServletResponse servResp = new MockHttpServletResponse();
@@ -791,10 +791,10 @@ public class SecurityWrapperResponseTest {
         SecurityWrapperResponse spyResp = spy(resp);
         Mockito.doCallRealMethod().when(spyResp).setStatus(200);;
         spyResp.setStatus(200);
-        
+
         verify(servResp, times(1)).setStatus(200);;
     }
-    
+
     @Test
     public void testSendStatusWithString() throws Exception{
         HttpServletResponse servResp = new MockHttpServletResponse();
@@ -803,7 +803,7 @@ public class SecurityWrapperResponseTest {
         SecurityWrapperResponse spyResp = spy(resp);
         Mockito.doCallRealMethod().when(spyResp).setStatus(200, "foo");;
         spyResp.setStatus(200, "foo");
-        
+
         verify(servResp, times(1)).sendError(200, "foo");;
     }
 }


### PR DESCRIPTION
Updates to SecurityWrapperResponse to provide more clear logging on addHeader and setHeader by clarifying whether the name or value attribute is at fault.