### PR TITLE
upgrade for convergence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -364,7 +364,7 @@
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-reflect</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.2</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -526,35 +526,24 @@
                 </dependencies>
                 <executions>
                     <execution>
-                      <id>enforce-bytecode-version</id>
                       <goals>
                         <goal>enforce</goal>
                       </goals>
                       <configuration>
                         <rules>
+                          <dependencyConvergence />
+                          <requireJavaVersion>
+                            <version>1.7</version>
+                              <message>
+                                ESAPI 2.x now uses the JDK1.7 for it's baseline. Please make sure that your
+                                JAVA_HOME environment variable is pointed to a JDK1.7 distribution.
+                              </message>
+                          </requireJavaVersion>
                           <enforceBytecodeVersion>
                             <maxJdkVersion>1.7</maxJdkVersion>
                           </enforceBytecodeVersion>
                         </rules>
-                        <fail>true</fail>
                       </configuration>
-                    </execution>
-                    <execution>
-                        <id>enforce-jdk-version</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireJavaVersion>
-                                    <version>1.7</version>
-                                    <message>
-                                        ESAPI 2.x now uses the JDK1.7 for it's baseline. Please make sure that your
-                                        JAVA_HOME environment variable is pointed to a JDK1.7 distribution.
-                                    </message>
-                                </requireJavaVersion>
-                            </rules>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
I have seen the commented text next to `powermock-api-mockito2` dependency in [pom.xml](https://github.com/ESAPI/esapi-java-legacy/blob/develop/pom.xml#L322) and I assume that we would like to have 100% convergence.

This pull request adds a rule for `maven-enforcer-plugin` that checks that.

I needed to upgrade `powermock-reflect` from 2.0.0 to 2.0.2 (didn't check if that works with JAVA 7).

I also merged two executions of the plugin into one:

1. if there is only one execution then the *id* is not needed
1. `<fail>` parameter for this plugin has **true** as default value