### PR TITLE
Issue 382: Build Fails on path with space

### DIFF
--- a/src/main/java/org/owasp/esapi/reference/DefaultSecurityConfiguration.java
+++ b/src/main/java/org/owasp/esapi/reference/DefaultSecurityConfiguration.java
@@ -20,6 +20,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -581,13 +582,17 @@ public class DefaultSecurityConfiguration implements SecurityConfiguration {
         }
 
 		if (fileUrl != null) {
-			String fileLocation = fileUrl.getFile();
-			f = new File(fileLocation);
-			if (f.exists()) {
-				logSpecial("Found in SystemResource Directory/resourceDirectory: " + f.getAbsolutePath());
-				return f;
-			} else {
-				logSpecial("Not found in SystemResource Directory/resourceDirectory (this should never happen): " + f.getAbsolutePath());
+			try {
+				String fileLocation = fileUrl.toURI().getPath();
+				f = new File(fileLocation);
+				if (f.exists()) {
+					logSpecial("Found in SystemResource Directory/resourceDirectory: " + f.getAbsolutePath());
+					return f;
+				} else {
+					logSpecial("Not found in SystemResource Directory/resourceDirectory (this should never happen): " + f.getAbsolutePath());
+				}
+			} catch (URISyntaxException e) {
+				logSpecial("Error while converting URL " + fileUrl + " to file path: " + e.getMessage());
 			}
 		} else {
 			logSpecial("Not found in SystemResource Directory/resourceDirectory: " + resourceDirectory + File.separator + filename);

--- a/src/test/java/org/owasp/esapi/crypto/CryptoTokenTest.java
+++ b/src/test/java/org/owasp/esapi/crypto/CryptoTokenTest.java
@@ -391,7 +391,9 @@ public class CryptoTokenTest {
     private static void nap(int n) {
         try {
             System.out.println("Sleeping " + n + " seconds...");
-            Thread.sleep( n * 1000 );
+            // adds additional time to make sure we sleep more than n seconds
+            int additionalTimeToSleep = 100;
+            Thread.sleep( n * 1000 + additionalTimeToSleep );
         } catch (InterruptedException e) {
             ;   // Ignore
         }

--- a/src/test/java/org/owasp/esapi/reference/ExtensiveEncoderURITest.java
+++ b/src/test/java/org/owasp/esapi/reference/ExtensiveEncoderURITest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -22,7 +21,7 @@ import org.owasp.esapi.Validator;
 
 @RunWith(Parameterized.class)
 public class ExtensiveEncoderURITest {
-	static List<String> inputs = new ArrayList<String>();
+	static List<String> inputs = new ArrayList<>();
 	Validator v = ESAPI.validator();
 	String uri;
 	boolean expected;
@@ -53,7 +52,7 @@ public class ExtensiveEncoderURITest {
 	}
 
 	@Test
-	public void testUrlsFromFile() throws Exception{
+	public void testUrlsFromFile() {
 		assertEquals(this.expected, v.isValidURI("URL", uri, false));
 	}
 

--- a/src/test/java/org/owasp/esapi/reference/ExtensiveEncoderURITest.java
+++ b/src/test/java/org/owasp/esapi/reference/ExtensiveEncoderURITest.java
@@ -2,10 +2,12 @@ package org.owasp.esapi.reference;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -34,14 +36,24 @@ public class ExtensiveEncoderURITest {
 	@Parameters
 	public static Collection<String> getMyUris() throws Exception{
 		URL url = ExtensiveEncoderURITest.class.getResource("/urisForTest.txt");
-		String fileName = url.getFile();
-		File urisForText = new File(fileName);
 		
-		inputs = Files.readAllLines(urisForText.toPath(), StandardCharsets.UTF_8);
-		
+		try( InputStream is = url.openStream() ) {
+			InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
+			BufferedReader br = new BufferedReader(isr);
+			inputs = readAllLines(br);
+		}
 		return inputs;
 	}
-	
+
+	private static List<String> readAllLines(BufferedReader br) throws IOException {
+		List<String> lines = new ArrayList<>();
+		String line;
+		while ((line = br.readLine()) != null) {
+			lines.add(line);
+		}
+		return lines;
+	}
+
 	@Test
 	public void testUrlsFromFile() throws Exception{
 		assertEquals(this.expected, v.isValidURI("URL", uri, false));

--- a/src/test/java/org/owasp/esapi/reference/ExtensiveEncoderURITest.java
+++ b/src/test/java/org/owasp/esapi/reference/ExtensiveEncoderURITest.java
@@ -36,10 +36,8 @@ public class ExtensiveEncoderURITest {
 	@Parameters
 	public static Collection<String> getMyUris() throws Exception{
 		URL url = ExtensiveEncoderURITest.class.getResource("/urisForTest.txt");
-		
-		try( InputStream is = url.openStream() ) {
-			InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
-			BufferedReader br = new BufferedReader(isr);
+
+		try( BufferedReader br = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8)) ) {
 			inputs = readAllLines(br);
 		}
 		return inputs;


### PR DESCRIPTION
This pull request contain changes for building the project in folder that contains spaces.

See also issue https://github.com/ESAPI/esapi-java-legacy/issues/382.

`URI` used instead of `URL` (see https://stackoverflow.com/a/13470643).

I believe the `DefaultSecurityConfiguration#getResourceFile` could be further improved, but that should be probably part of another pull request, or maybe even part of version 3.x...