### PR TITLE
Issue 571: JavaLogFactory ALWAYS

### DIFF
--- a/src/main/java/org/owasp/esapi/Logger.java
+++ b/src/main/java/org/owasp/esapi/Logger.java
@@ -401,6 +401,8 @@ public interface Logger {
 
 	/**
      * Log an event regardless of what logging level is enabled.
+     * <br>
+     * Note that logging will not occur if the underlying logging implementation has logging disabled.
      * 
      * @param type 
      * 		the type of event
@@ -412,6 +414,8 @@ public interface Logger {
 	/**
      * Log an event regardless of what logging level is enabled
      * and also record the stack trace associated with the event.
+     * <br>
+     * Note that logging will not occur if the underlying logging implementation has logging disabled.
      * 
      * @param type 
      * 		the type of event 

--- a/src/main/java/org/owasp/esapi/logging/java/ESAPICustomJavaLevel.java
+++ b/src/main/java/org/owasp/esapi/logging/java/ESAPICustomJavaLevel.java
@@ -31,6 +31,11 @@ public class ESAPICustomJavaLevel extends Level {
     public static final Level ERROR_LEVEL = new ESAPICustomJavaLevel( "ERROR", Level.SEVERE.intValue() - 1);
 
     /**
+     * Defines a custom level that should result in content always being recorded, unless the Java Logging configuration is set to OFF.
+     */
+    public static final Level ALWAYS_LEVEL = new ESAPICustomJavaLevel( "ERROR", Level.OFF.intValue() - 1);
+    
+    /**
      * Constructs an instance of a JavaLoggerLevel which essentially provides a mapping between the name of
      * the defined level and its numeric value.
      * 

--- a/src/main/java/org/owasp/esapi/logging/java/ESAPICustomJavaLevel.java
+++ b/src/main/java/org/owasp/esapi/logging/java/ESAPICustomJavaLevel.java
@@ -18,7 +18,7 @@ package org.owasp.esapi.logging.java;
 import java.util.logging.Level;
 
 /**
- *  A custom logging level defined between Level.SEVERE and Level.WARNING in logger.
+ *  Definitions of customized Java Logging Level options to map ESAPI behavior to the desired Java Log output behaviors.
  */
 public class ESAPICustomJavaLevel extends Level {
 
@@ -33,7 +33,7 @@ public class ESAPICustomJavaLevel extends Level {
     /**
      * Defines a custom level that should result in content always being recorded, unless the Java Logging configuration is set to OFF.
      */
-    public static final Level ALWAYS_LEVEL = new ESAPICustomJavaLevel( "ERROR", Level.OFF.intValue() - 1);
+    public static final Level ALWAYS_LEVEL = new ESAPICustomJavaLevel( "ALWAYS", Level.OFF.intValue() - 1);
     
     /**
      * Constructs an instance of a JavaLoggerLevel which essentially provides a mapping between the name of

--- a/src/main/java/org/owasp/esapi/logging/java/ESAPICustomJavaLevel.java
+++ b/src/main/java/org/owasp/esapi/logging/java/ESAPICustomJavaLevel.java
@@ -20,7 +20,7 @@ import java.util.logging.Level;
 /**
  *  A custom logging level defined between Level.SEVERE and Level.WARNING in logger.
  */
-public class ESAPIErrorJavaLevel extends Level {
+public class ESAPICustomJavaLevel extends Level {
 
     protected static final long serialVersionUID = 1L;
 
@@ -28,7 +28,7 @@ public class ESAPIErrorJavaLevel extends Level {
      * Defines a custom error level below SEVERE but above WARNING since this level isn't defined directly
      * by java.util.Logger already.
      */
-    public static final Level ERROR_LEVEL = new ESAPIErrorJavaLevel( "ERROR", Level.SEVERE.intValue() - 1);
+    public static final Level ERROR_LEVEL = new ESAPICustomJavaLevel( "ERROR", Level.SEVERE.intValue() - 1);
 
     /**
      * Constructs an instance of a JavaLoggerLevel which essentially provides a mapping between the name of
@@ -37,7 +37,7 @@ public class ESAPIErrorJavaLevel extends Level {
      * @param name The name of the JavaLoggerLevel
      * @param value The associated numeric value
      */
-    private ESAPIErrorJavaLevel(String name, int value) {
+    private ESAPICustomJavaLevel(String name, int value) {
         super(name, value);
     }
 }

--- a/src/main/java/org/owasp/esapi/logging/java/ESAPIErrorJavaLevel.java
+++ b/src/main/java/org/owasp/esapi/logging/java/ESAPIErrorJavaLevel.java
@@ -19,6 +19,8 @@ import java.util.logging.Level;
 
 /**
  *  A custom logging level defined between Level.SEVERE and Level.WARNING in logger.
+ *  @deprecated
+ *  @see ESAPICustomJavaLevel#ERROR_LEVEL
  */
 public class ESAPIErrorJavaLevel extends Level {
 
@@ -27,8 +29,10 @@ public class ESAPIErrorJavaLevel extends Level {
     /**
      * Defines a custom error level below SEVERE but above WARNING since this level isn't defined directly
      * by java.util.Logger already.
+     * @deprecated
+     * @see ESAPICustomJavaLevel#ERROR_LEVEL
      */
-    public static final Level ERROR_LEVEL = new ESAPIErrorJavaLevel( "ERROR", Level.SEVERE.intValue() - 1);
+    public static final Level ERROR_LEVEL = new ESAPIErrorJavaLevel( ESAPICustomJavaLevel.ERROR_LEVEL.getName(),ESAPICustomJavaLevel.ERROR_LEVEL.intValue());
 
     /**
      * Constructs an instance of a JavaLoggerLevel which essentially provides a mapping between the name of

--- a/src/main/java/org/owasp/esapi/logging/java/ESAPIErrorJavaLevel.java
+++ b/src/main/java/org/owasp/esapi/logging/java/ESAPIErrorJavaLevel.java
@@ -1,0 +1,43 @@
+/**
+ * OWASP Enterprise Security API (ESAPI)
+ * 
+ * This file is part of the Open Web Application Security Project (OWASP)
+ * Enterprise Security API (ESAPI) project. For details, please see
+ * <a href="http://www.owasp.org/index.php/ESAPI">http://www.owasp.org/index.php/ESAPI</a>.
+ *
+ * Copyright (c) 2007 - The OWASP Foundation
+ * 
+ * The ESAPI is published by OWASP under the BSD license. You should read and accept the
+ * LICENSE before you use, modify, and/or redistribute this software.
+ * 
+ * @created 2019
+ */
+
+package org.owasp.esapi.logging.java;
+
+import java.util.logging.Level;
+
+/**
+ *  A custom logging level defined between Level.SEVERE and Level.WARNING in logger.
+ */
+public class ESAPIErrorJavaLevel extends Level {
+
+    protected static final long serialVersionUID = 1L;
+
+    /**
+     * Defines a custom error level below SEVERE but above WARNING since this level isn't defined directly
+     * by java.util.Logger already.
+     */
+    public static final Level ERROR_LEVEL = new ESAPIErrorJavaLevel( "ERROR", Level.SEVERE.intValue() - 1);
+
+    /**
+     * Constructs an instance of a JavaLoggerLevel which essentially provides a mapping between the name of
+     * the defined level and its numeric value.
+     * 
+     * @param name The name of the JavaLoggerLevel
+     * @param value The associated numeric value
+     */
+    private ESAPIErrorJavaLevel(String name, int value) {
+        super(name, value);
+    }
+}

--- a/src/main/java/org/owasp/esapi/logging/java/ESAPIErrorJavaLevel.java
+++ b/src/main/java/org/owasp/esapi/logging/java/ESAPIErrorJavaLevel.java
@@ -19,7 +19,7 @@ import java.util.logging.Level;
 
 /**
  *  A custom logging level defined between Level.SEVERE and Level.WARNING in logger.
- *  @deprecated
+ *  @deprecated 10/24/2020 : References should use ESAPICustomJavaLevel.ERROR_LEVEL
  *  @see ESAPICustomJavaLevel#ERROR_LEVEL
  */
 public class ESAPIErrorJavaLevel extends Level {

--- a/src/main/java/org/owasp/esapi/logging/java/JavaLogFactory.java
+++ b/src/main/java/org/owasp/esapi/logging/java/JavaLogFactory.java
@@ -67,7 +67,7 @@ public class JavaLogFactory implements LogFactory {
         JAVA_LOG_APPENDER = createLogAppender(logUserInfo, logClientInfo, logServerIp, logApplicationName, appName);
 
         Map<Integer, JavaLogLevelHandler> levelLookup = new HashMap<>();
-        levelLookup.put(Logger.ALL, JavaLogLevelHandlers.ALL);
+        levelLookup.put(Logger.ALL, JavaLogLevelHandlers.ALWAYS);
         levelLookup.put(Logger.TRACE, JavaLogLevelHandlers.FINEST);
         levelLookup.put(Logger.DEBUG, JavaLogLevelHandlers.FINE);
         levelLookup.put(Logger.INFO, JavaLogLevelHandlers.INFO);

--- a/src/main/java/org/owasp/esapi/logging/java/JavaLogLevelHandlers.java
+++ b/src/main/java/org/owasp/esapi/logging/java/JavaLogLevelHandlers.java
@@ -27,7 +27,7 @@ public enum JavaLogLevelHandlers implements JavaLogLevelHandler {
 	FINER(Level.FINER),
 	FINEST(Level.FINEST),
 	ALL(Level.ALL),
-	ERROR(ESAPIErrorJavaLevel.ERROR_LEVEL);
+	ERROR(ESAPICustomJavaLevel.ERROR_LEVEL);
 
 	private final Level level;
 	

--- a/src/main/java/org/owasp/esapi/logging/java/JavaLogLevelHandlers.java
+++ b/src/main/java/org/owasp/esapi/logging/java/JavaLogLevelHandlers.java
@@ -26,7 +26,7 @@ public enum JavaLogLevelHandlers implements JavaLogLevelHandler {
 	FINE(Level.FINE),
 	FINER(Level.FINER),
 	FINEST(Level.FINEST),
-	ALL(Level.ALL),
+	ALWAYS(ESAPICustomJavaLevel.ALWAYS_LEVEL),
 	ERROR(ESAPICustomJavaLevel.ERROR_LEVEL);
 
 	private final Level level;

--- a/src/test/java/org/owasp/esapi/logging/java/JavaLogLevelHandlersTest.java
+++ b/src/test/java/org/owasp/esapi/logging/java/JavaLogLevelHandlersTest.java
@@ -45,6 +45,20 @@ public class JavaLogLevelHandlersTest {
     }
 
     @Test
+    public void testAlwaysDelegation() {
+        JavaLogLevelHandlers.ALWAYS.isEnabled(mockLogger);
+        JavaLogLevelHandlers.ALWAYS.log(mockLogger, testName.getMethodName());
+        JavaLogLevelHandlers.ALWAYS.log(mockLogger, testName.getMethodName(), testException);
+
+        Level expectedJavaLevel = ESAPICustomJavaLevel.ALWAYS_LEVEL;
+
+        Mockito.verify(mockLogger, Mockito.times(1)).isLoggable(expectedJavaLevel);
+        Mockito.verify(mockLogger, Mockito.times(1)).log(expectedJavaLevel, testName.getMethodName());
+        Mockito.verify(mockLogger, Mockito.times(1)).log(expectedJavaLevel, testName.getMethodName(), testException);
+        Mockito.verifyNoMoreInteractions(mockLogger);
+    }
+    
+    @Test
     public void testWarnDelegation() {
         JavaLogLevelHandlers.WARNING.isEnabled(mockLogger);
         JavaLogLevelHandlers.WARNING.log(mockLogger, testName.getMethodName());

--- a/src/test/java/org/owasp/esapi/logging/java/JavaLogLevelHandlersTest.java
+++ b/src/test/java/org/owasp/esapi/logging/java/JavaLogLevelHandlersTest.java
@@ -36,7 +36,7 @@ public class JavaLogLevelHandlersTest {
         JavaLogLevelHandlers.ERROR.log(mockLogger, testName.getMethodName());
         JavaLogLevelHandlers.ERROR.log(mockLogger, testName.getMethodName(), testException);
 
-        Level expectedJavaLevel = ESAPIErrorJavaLevel.ERROR_LEVEL;
+        Level expectedJavaLevel = ESAPICustomJavaLevel.ERROR_LEVEL;
 
         Mockito.verify(mockLogger, Mockito.times(1)).isLoggable(expectedJavaLevel);
         Mockito.verify(mockLogger, Mockito.times(1)).log(expectedJavaLevel, testName.getMethodName());


### PR DESCRIPTION
https://github.com/ESAPI/esapi-java-legacy/issues/571#issuecomment-691674605

Adding implementation noted in the comment listed above.

Caveat to this implementation is that if the Java Logging configuration is set to OFF then no logging will occur.  I don't think there's much that can be done about this particular use case.