### PR TITLE
Address latent confusion caused by obsolete / deprecated ESAPI methods related to Issue #593

### DIFF
--- a/configuration/esapi/ESAPI.properties
+++ b/configuration/esapi/ESAPI.properties
@@ -387,11 +387,6 @@ Logger.LogEncodingRequired=false
 Logger.LogApplicationName=true
 # Determines whether ESAPI should log the server IP and port. This might be clutter in some single-server environments.
 Logger.LogServerIP=true
-# LogFileName, the name of the logging file. Provide a full directory path (e.g., C:\\ESAPI\\ESAPI_logging_file) if you
-# want to place it in a specific directory.
-Logger.LogFileName=ESAPI_logging_file
-# MaxLogFileSize, the max size (in bytes) of a single log file before it cuts over to a new one (default is 10,000,000)
-Logger.MaxLogFileSize=10000000
 # Determines whether ESAPI should log the user info.
 Logger.UserInfo=true
 # Determines whether ESAPI should log the session id and client IP.
@@ -487,7 +482,7 @@ Validator.HTTPJSESSIONID=^[A-Z0-9]{10,32}$
 # Contributed by Fraenku@gmx.ch
 # Github Issue 126 https://github.com/ESAPI/esapi-java-legacy/issues/126
 Validator.HTTPParameterName=^[a-zA-Z0-9_\\-]{1,32}$
-Validator.HTTPParameterValue=^[\\p{L}\\p{N}.\\-/+=_ !$*?@]{0,1000}$
+Validator.HTTPParameterValue=^[-\\p{L}\\p{N}./+=_ !$*?@]{0,1000}$
 Validator.HTTPContextPath=^/[a-zA-Z0-9.\\-_]*$
 Validator.HTTPQueryString=^([a-zA-Z0-9_\\-]{1,32}=[\\p{L}\\p{N}.\\-/+=_ !$*?@%]*&?)*$
 Validator.HTTPURI=^/([a-zA-Z0-9.\\-_]*/?)*$

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.owasp.esapi</groupId>
     <artifactId>esapi</artifactId>
-    <version>2.3.0.0-SNAPSHOT</version>
+    <version>2.2.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <distributionManagement>

--- a/src/main/java/org/owasp/esapi/SecurityConfiguration.java
+++ b/src/main/java/org/owasp/esapi/SecurityConfiguration.java
@@ -731,34 +731,6 @@ public interface SecurityConfiguration extends EsapiPropertyLoader {
 	boolean getLogServerIP();
 
 	/**
-	 * Returns the current log level.
-	 * @return	An integer representing the current log level.
-     * @deprecated Use SecurityConfiguration.getIntProp("appropriate_esapi_prop_name") instead.
-	 */
-	@Deprecated
-    int getLogLevel();
-	
-    /**
-     * Get the name of the log file specified in the ESAPI configuration properties file. Return a default value 
-     * if it is not specified.
-     * 
-     * @return the log file name defined in the properties file.
-     * @deprecated Use SecurityConfiguration.getStringProp("appropriate_esapi_prop_name") instead.
-     */
-	@Deprecated
-    String getLogFileName();
-
-    /**
-     * Get the maximum size of a single log file from the ESAPI configuration properties file. Return a default value 
-     * if it is not specified. Once the log hits this file size, it will roll over into a new log.
-     * 
-     * @return the maximum size of a single log file (in bytes).
-     * @deprecated Use SecurityConfiguration.getIntProp("appropriate_esapi_prop_name") instead.
-     */
-	@Deprecated
-    int getMaxLogFileSize();
-
-	/**
 	 * Models a simple threshold as a count and an interval, along with a set of actions to take if 
 	 * the threshold is exceeded. These thresholds are used to define when the accumulation of a particular event
 	 * has met a set number within the specified time period. Once a threshold value has been met, various

--- a/src/main/java/org/owasp/esapi/reference/DefaultSecurityConfiguration.java
+++ b/src/main/java/org/owasp/esapi/reference/DefaultSecurityConfiguration.java
@@ -147,9 +147,6 @@ public class DefaultSecurityConfiguration implements SecurityConfiguration {
     public static final String HTTP_SESSION_ID_NAME = "HttpUtilities.HttpSessionIdName";
 
     public static final String APPLICATION_NAME = "Logger.ApplicationName";
-    public static final String LOG_LEVEL = "Logger.LogLevel";
-    public static final String LOG_FILE_NAME = "Logger.LogFileName";
-    public static final String MAX_LOG_FILE_SIZE = "Logger.MaxLogFileSize";
     public static final String LOG_ENCODING_REQUIRED = "Logger.LogEncodingRequired";
     public static final String LOG_APPLICATION_NAME = "Logger.LogApplicationName";
     public static final String LOG_SERVER_IP = "Logger.LogServerIP";
@@ -174,13 +171,6 @@ public class DefaultSecurityConfiguration implements SecurityConfiguration {
     private static final String logSpecialValue = System.getProperty(DISCARD_LOGSPECIAL, "false");
 
 
-    /**
-	 * The default max log file size is set to 10,000,000 bytes (10 Meg). If the current log file exceeds the current
-	 * max log file size, the logger will move the old log data into another log file. There currently is a max of
-	 * 1000 log files of the same name. If that is exceeded it will presumably start discarding the oldest logs.
-	 */
-	public static final int DEFAULT_MAX_LOG_FILE_SIZE = 10000000;
-	
     protected final int MAX_REDIRECT_LOCATION = 1000;
     
     /*
@@ -1019,49 +1009,6 @@ public class DefaultSecurityConfiguration implements SecurityConfiguration {
         return null;
     }
 
-    /**
-	 * {@inheritDoc}
-	 */
-    public int getLogLevel() {
-        String level = getESAPIProperty(LOG_LEVEL, "WARNING" );
-
-        if (level.equalsIgnoreCase("OFF"))
-            return Logger.OFF;
-        if (level.equalsIgnoreCase("FATAL"))
-            return Logger.FATAL;
-        if (level.equalsIgnoreCase("ERROR"))
-            return Logger.ERROR ;
-        if (level.equalsIgnoreCase("WARNING"))
-            return Logger.WARNING;
-        if (level.equalsIgnoreCase("INFO"))
-            return Logger.INFO;
-        if (level.equalsIgnoreCase("DEBUG"))
-            return Logger.DEBUG;
-        if (level.equalsIgnoreCase("TRACE"))
-            return Logger.TRACE;
-        if (level.equalsIgnoreCase("ALL"))
-            return Logger.ALL;
-
-		// This error is NOT logged the normal way because the logger constructor calls getLogLevel() and if this error occurred it would cause
-		// an infinite loop.
-        logSpecial("The LOG-LEVEL property in the ESAPI properties file has the unrecognized value: " + level + ". Using default: WARNING", null);
-        return Logger.WARNING;  // Note: The default logging level is WARNING.
-    }
-
-    /**
-	 * {@inheritDoc}
-	 */
-    public String getLogFileName() {
-    	return getESAPIProperty( LOG_FILE_NAME, "ESAPI_logging_file" );
-    }
-
-	/**
-	 * {@inheritDoc}
-	 */
-    public int getMaxLogFileSize() {
-    	return getESAPIProperty( MAX_LOG_FILE_SIZE, DEFAULT_MAX_LOG_FILE_SIZE );
-    }
-    
     /**
 	 * {@inheritDoc}
 	 */

--- a/src/main/java/org/owasp/esapi/waf/configuration/AppGuardianConfiguration.java
+++ b/src/main/java/org/owasp/esapi/waf/configuration/AppGuardianConfiguration.java
@@ -111,32 +111,6 @@ public class AppGuardianConfiguration {
 		cookieRules = new ArrayList<Rule>();
 	}
 
-	/*
-	 * The following methods are all deprecated because
-	 * we use ESAPI logging structures now.
-	 */
-	@Deprecated
-	public Level getLogLevel() {
-		return logLevel;
-	}
-	
-	@Deprecated
-	public void setLogLevel(Level level) {
-		LOG_LEVEL = level;
-		this.logLevel = level;
-	}
-	
-	@Deprecated
-	public void setLogDirectory(String dir) {
-		LOG_DIRECTORY = dir;
-		this.logDirectory = dir;
-	}
-	
-	@Deprecated
-	public String getLogDirectory() {
-		return logDirectory;
-	}
-	
 	public String getDefaultErrorPage() {
 		return defaultErrorPage;
 	}

--- a/src/main/java/org/owasp/esapi/waf/configuration/ConfigurationParser.java
+++ b/src/main/java/org/owasp/esapi/waf/configuration/ConfigurationParser.java
@@ -30,7 +30,6 @@ import nu.xom.Elements;
 import nu.xom.ParsingException;
 import nu.xom.ValidityException;
 
-import org.apache.log4j.Level;
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.waf.ConfigurationException;
 import org.owasp.esapi.waf.rules.AddHTTPOnlyFlagRule;
@@ -141,16 +140,6 @@ public class ConfigurationParser {
 				} catch (Exception e) {
 					config.setDefaultResponseCode( DEFAULT_RESPONSE_CODE );
 				}
-			}
-			
-			/*
-			 * The WAF separate logging is going to be merged in the 2.0
-			 * release, so this is deprecated.
-			 */
-			Element loggingRoot = settingsRoot.getFirstChildElement("logging");
-			if ( loggingRoot != null ) {
-				config.setLogDirectory(loggingRoot.getFirstChildElement("log-directory").getValue());
-				config.setLogLevel(Level.toLevel(loggingRoot.getFirstChildElement("log-level").getValue()));
 			}
 			
 			/**

--- a/src/test/java/org/owasp/esapi/SecurityConfigurationWrapper.java
+++ b/src/test/java/org/owasp/esapi/SecurityConfigurationWrapper.java
@@ -551,33 +551,6 @@ public class SecurityConfigurationWrapper implements SecurityConfiguration
 		return wrapped.getLogServerIP();
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
-	// @Override
-	public int getLogLevel()
-	{
-		return wrapped.getLogLevel();
-	}
-	
-	/**
-	 * {@inheritDoc}
-	 */
-	// @Override
-	public String getLogFileName()
-	{
-		return wrapped.getLogFileName();
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	// @Override
-	public int getMaxLogFileSize()
-	{
-	 	return wrapped.getMaxLogFileSize();
-	}
-
 	@Override
 	public int getIntProp(String propertyName) throws ConfigurationException {
 		return wrapped.getIntProp(propertyName);

--- a/src/test/java/org/owasp/esapi/reference/DefaultSecurityConfigurationTest.java
+++ b/src/test/java/org/owasp/esapi/reference/DefaultSecurityConfigurationTest.java
@@ -352,49 +352,6 @@ public class DefaultSecurityConfigurationTest {
 		assertFalse(secConf.getDisableIntrusionDetection());
 	}
 	
-	@Test
-	public void testGetLogLevel() {
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
-		assertEquals(Logger.WARNING, secConf.getLogLevel());
-		
-		secConf = this.createWithProperty(DefaultSecurityConfiguration.LOG_LEVEL, "trace");
-		assertEquals(Logger.TRACE, secConf.getLogLevel());
-		
-		secConf = this.createWithProperty(DefaultSecurityConfiguration.LOG_LEVEL, "Off");
-		assertEquals(Logger.OFF, secConf.getLogLevel());
-		
-		secConf = this.createWithProperty(DefaultSecurityConfiguration.LOG_LEVEL, "all");
-		assertEquals(Logger.ALL, secConf.getLogLevel());
-		
-		secConf = this.createWithProperty(DefaultSecurityConfiguration.LOG_LEVEL, "DEBUG");
-		assertEquals(Logger.DEBUG, secConf.getLogLevel());
-		
-		secConf = this.createWithProperty(DefaultSecurityConfiguration.LOG_LEVEL, "info");
-		assertEquals(Logger.INFO, secConf.getLogLevel());
-		
-		secConf = this.createWithProperty(DefaultSecurityConfiguration.LOG_LEVEL, "ERROR");
-		assertEquals(Logger.ERROR, secConf.getLogLevel());
-	}
-	
-	@Test
-	public void testGetLogFileName() {
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
-		assertEquals("ESAPI_logging_file", secConf.getLogFileName());
-		
-		secConf = this.createWithProperty(DefaultSecurityConfiguration.LOG_FILE_NAME, "log.txt");
-		assertEquals("log.txt", secConf.getLogFileName());
-	}
-	
-	@Test
-	public void testGetMaxLogFileSize() {
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
-		assertEquals(DefaultSecurityConfiguration.DEFAULT_MAX_LOG_FILE_SIZE, secConf.getMaxLogFileSize());
-		
-		int maxLogSize = (1024 * 1000);
-		secConf = this.createWithProperty(DefaultSecurityConfiguration.MAX_LOG_FILE_SIZE, String.valueOf(maxLogSize));
-		assertEquals(maxLogSize, secConf.getMaxLogFileSize());
-	}
-
     @Test
     public void testNoSuchPropFile(){
         try {

--- a/src/test/resources/esapi/ESAPI-CommaValidatorFileChecker.properties
+++ b/src/test/resources/esapi/ESAPI-CommaValidatorFileChecker.properties
@@ -397,12 +397,6 @@ Logger.LogEncodingRequired=false
 Logger.LogApplicationName=true
 # Determines whether ESAPI should log the server IP and port. This might be clutter in some single-server environments.
 Logger.LogServerIP=true
-# LogFileName, the name of the logging file. Provide a full directory path (e.g., C:\\ESAPI\\ESAPI_logging_file) if you
-# want to place it in a specific directory.
-Logger.LogFileName=ESAPI_logging_file
-# MaxLogFileSize, the max size (in bytes) of a single log file before it cuts over to a new one (default is 10,000,000)
-Logger.MaxLogFileSize=10000000
-
 
 #===========================================================================
 # ESAPI Intrusion Detection
@@ -485,7 +479,7 @@ Validator.HTTPJSESSIONID=^[A-Z0-9]{10,30}$
 # Contributed by Fraenku@gmx.ch
 # Googlecode Issue 116 (http://code.google.com/p/owasp-esapi-java/issues/detail?id=116)
 Validator.HTTPParameterName=^[a-zA-Z0-9_\\-]{1,32}$
-Validator.HTTPParameterValue=^[\\p{L}\\p{N}.\\-/+=_ !$*?@]{0,1000}$
+Validator.HTTPParameterValue=^[-\\p{L}\\p{N}./+=_ !$*?@]{0,1000}$
 Validator.HTTPContextPath=^/[a-zA-Z0-9.\\-_]*$
 Validator.HTTPQueryString=^([a-zA-Z0-9_\\-]{1,32}=[\\p{L}\\p{N}.\\-/+=_ !$*?@%]*&?)*$
 Validator.HTTPURI=^/([a-zA-Z0-9.\\-_]*/?)*$

--- a/src/test/resources/esapi/ESAPI-DualValidatorFileChecker.properties
+++ b/src/test/resources/esapi/ESAPI-DualValidatorFileChecker.properties
@@ -398,12 +398,6 @@ Logger.LogEncodingRequired=false
 Logger.LogApplicationName=true
 # Determines whether ESAPI should log the server IP and port. This might be clutter in some single-server environments.
 Logger.LogServerIP=true
-# LogFileName, the name of the logging file. Provide a full directory path (e.g., C:\\ESAPI\\ESAPI_logging_file) if you
-# want to place it in a specific directory.
-Logger.LogFileName=ESAPI_logging_file
-# MaxLogFileSize, the max size (in bytes) of a single log file before it cuts over to a new one (default is 10,000,000)
-Logger.MaxLogFileSize=10000000
-
 
 #===========================================================================
 # ESAPI Intrusion Detection
@@ -486,7 +480,7 @@ Validator.HTTPJSESSIONID=^[A-Z0-9]{10,30}$
 # Contributed by Fraenku@gmx.ch
 # Googlecode Issue 116 (http://code.google.com/p/owasp-esapi-java/issues/detail?id=116)
 Validator.HTTPParameterName=^[a-zA-Z0-9_\\-]{1,32}$
-Validator.HTTPParameterValue=^[\\p{L}\\p{N}.\\-/+=_ !$*?@]{0,1000}$
+Validator.HTTPParameterValue=^[-\\p{L}\\p{N}./+=_ !$*?@]{0,1000}$
 Validator.HTTPContextPath=^/[a-zA-Z0-9.\\-_]*$
 Validator.HTTPQueryString=^([a-zA-Z0-9_\\-]{1,32}=[\\p{L}\\p{N}.\\-/+=_ !$*?@%]*&?)*$
 Validator.HTTPURI=^/([a-zA-Z0-9.\\-_]*/?)*$

--- a/src/test/resources/esapi/ESAPI-QuotedValidatorFileChecker.properties
+++ b/src/test/resources/esapi/ESAPI-QuotedValidatorFileChecker.properties
@@ -396,12 +396,6 @@ Logger.LogEncodingRequired=false
 Logger.LogApplicationName=true
 # Determines whether ESAPI should log the server IP and port. This might be clutter in some single-server environments.
 Logger.LogServerIP=true
-# LogFileName, the name of the logging file. Provide a full directory path (e.g., C:\\ESAPI\\ESAPI_logging_file) if you
-# want to place it in a specific directory.
-Logger.LogFileName=ESAPI_logging_file
-# MaxLogFileSize, the max size (in bytes) of a single log file before it cuts over to a new one (default is 10,000,000)
-Logger.MaxLogFileSize=10000000
-
 
 #===========================================================================
 # ESAPI Intrusion Detection
@@ -484,7 +478,7 @@ Validator.HTTPJSESSIONID=^[A-Z0-9]{10,30}$
 # Contributed by Fraenku@gmx.ch
 # Googlecode Issue 116 (http://code.google.com/p/owasp-esapi-java/issues/detail?id=116)
 Validator.HTTPParameterName=^[a-zA-Z0-9_\\-]{1,32}$
-Validator.HTTPParameterValue=^[\\p{L}\\p{N}.\\-/+=_ !$*?@]{0,1000}$
+Validator.HTTPParameterValue=^[-\\p{L}\\p{N}./+=_ !$*?@]{0,1000}$
 Validator.HTTPContextPath=^/[a-zA-Z0-9.\\-_]*$
 Validator.HTTPQueryString=^([a-zA-Z0-9_\\-]{1,32}=[\\p{L}\\p{N}.\\-/+=_ !$*?@%]*&?)*$
 Validator.HTTPURI=^/([a-zA-Z0-9.\\-_]*/?)*$

--- a/src/test/resources/esapi/ESAPI-SingleValidatorFileChecker.properties
+++ b/src/test/resources/esapi/ESAPI-SingleValidatorFileChecker.properties
@@ -396,12 +396,6 @@ Logger.LogEncodingRequired=false
 Logger.LogApplicationName=true
 # Determines whether ESAPI should log the server IP and port. This might be clutter in some single-server environments.
 Logger.LogServerIP=true
-# LogFileName, the name of the logging file. Provide a full directory path (e.g., C:\\ESAPI\\ESAPI_logging_file) if you
-# want to place it in a specific directory.
-Logger.LogFileName=ESAPI_logging_file
-# MaxLogFileSize, the max size (in bytes) of a single log file before it cuts over to a new one (default is 10,000,000)
-Logger.MaxLogFileSize=10000000
-
 
 #===========================================================================
 # ESAPI Intrusion Detection
@@ -484,7 +478,7 @@ Validator.HTTPJSESSIONID=^[A-Z0-9]{10,30}$
 # Contributed by Fraenku@gmx.ch
 # Googlecode Issue 116 (http://code.google.com/p/owasp-esapi-java/issues/detail?id=116)
 Validator.HTTPParameterName=^[a-zA-Z0-9_\\-]{1,32}$
-Validator.HTTPParameterValue=^[\\p{L}\\p{N}.\\-/+=_ !$*?@]{0,1000}$
+Validator.HTTPParameterValue=^[-\\p{L}\\p{N}./+=_ !$*?@]{0,1000}$
 Validator.HTTPContextPath=^/[a-zA-Z0-9.\\-_]*$
 Validator.HTTPQueryString=^([a-zA-Z0-9_\\-]{1,32}=[\\p{L}\\p{N}.\\-/+=_ !$*?@%]*&?)*$
 Validator.HTTPURI=^/([a-zA-Z0-9.\\-_]*/?)*$

--- a/src/test/resources/esapi/ESAPI.properties
+++ b/src/test/resources/esapi/ESAPI.properties
@@ -419,11 +419,6 @@ Logger.LogEncodingRequired=false
 Logger.LogApplicationName=true
 # Determines whether ESAPI should log the server IP and port. This might be clutter in some single-server environments.
 Logger.LogServerIP=true
-# LogFileName, the name of the logging file. Provide a full directory path (e.g., C:\\ESAPI\\ESAPI_logging_file) if you
-# want to place it in a specific directory.
-Logger.LogFileName=ESAPI_logging_file
-# MaxLogFileSize, the max size (in bytes) of a single log file before it cuts over to a new one (default is 10,000,000)
-Logger.MaxLogFileSize=10000000
 # Determines whether ESAPI should log the user info.
 Logger.UserInfo=true
 # Determines whether ESAPI should log the session id and client IP.


### PR DESCRIPTION
Issue #593 really isn't a bug in ESAPI, but id did reveal some significant understandings regarding ESAPI logging and how it is controlled.

The purpose of this PR is to try to clear up some of that confusion that is caused by old methods and properties that were never actually implemented to do what was expected, but that was documented (in both Javadoc and the ESAPI.properties files).