### PR TITLE
Suggested pom.xml updates and XmlEsapiPropertyLoader.java improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,16 +132,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.jmh>1.23</version.jmh>
+        <version.jmh>1.28</version.jmh>
+        <!-- Note: powermock v2.0.8 doesn't exist. v2.0.9+ requires mockito-core v3+, which requires Java 8 -->
         <version.powermock>2.0.7</version.powermock>
         <version.spotbugs>4.2.0</version.spotbugs>
-
-        <!-- Upgrading to 3.0.0-M3+ causes this test case error:
-                org.owasp.esapi.reference.DefaultValidatorInputStringAPITest.getValidInputNullAllowedPassthrough  Time elapsed: 2.057 s  <<< ERROR!
-                java.lang.OutOfMemoryError: PermGen space
-             when running tests with Java 7 on Mac OS X. No problems observed on Linux.
-        -->
-        <version.surefire>3.0.0-M2</version.surefire>
+        <version.surefire>3.0.0-M5</version.surefire>
     </properties>
 
     <dependencies>
@@ -235,8 +230,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache-extras.beanshell</groupId>
-                <artifactId>bsh</artifactId>
-                <version>2.0b6</version>
+            <artifactId>bsh</artifactId>
+            <version>2.0b6</version>
         </dependency>
         <dependency>
             <groupId>org.owasp.antisamy</groupId>
@@ -248,48 +243,18 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.30</version>
         </dependency>
-
-        <!--
-             FORCE SPECIFIC VERSIONS OF TRANSITIVE DEPENDENCIES EXCLUDED ABOVE.
-             This is to force patched versions of these libraries with known CVEs against them.
-        -->
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <!-- Note: commons-io:2.7+ require Java 8, so can't upgrade past 2.6 -->
-            <version>2.6</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.xmlgraphics</groupId>
-            <artifactId>batik-css</artifactId>
-            <version>1.14</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-io</groupId>
-                    <artifactId>commons-io</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>xalan</groupId>
-            <artifactId>xalan</artifactId>
-            <version>2.7.2</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>xml-apis</groupId>
-                    <artifactId>xml-apis</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
         <dependency>
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
             <version>1.4.01</version>
         </dependency>
+
+        <!--
+             FORCE SPECIFIC VERSIONS OF TRANSITIVE DEPENDENCIES EXCLUDED ABOVE.
+             This is to force patched versions of these libraries with known CVEs against them.
+        -->
+
+        <!-- No forced upgrades required currently -->
 
         <!-- SpotBugs dependencies -->
         <dependency>
@@ -298,24 +263,30 @@
             <version>${version.spotbugs}</version>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>net.jcip</groupId>
-            <artifactId>jcip-annotations</artifactId>
-            <version>1.0</version>
-            <optional>true</optional>
-        </dependency>
 
         <!-- Dependencies which are ONLY used for JUnit tests -->
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.15</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
             <version>1.68</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-api-mockito -->
@@ -353,6 +324,19 @@
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
+            <artifactId>powermock-core</artifactId>
+            <version>${version.powermock}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                  <!-- We exclude this here, because we import the version we need above, and this imports a newer version. -->
+                  <groupId>org.javassist</groupId>
+                  <artifactId>javassist</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
             <version>${version.powermock}</version>
             <scope>test</scope>
@@ -386,12 +370,6 @@
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
-            <version>${version.jmh}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.openjdk.jmh</groupId>
-            <artifactId>jmh-generator-annprocess</artifactId>
             <version>${version.jmh}</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,8 @@
         <version.jmh>1.28</version.jmh>
         <!-- Note: powermock v2.0.8 doesn't exist. v2.0.9+ requires mockito-core v3+, which requires Java 8 -->
         <version.powermock>2.0.7</version.powermock>
-        <version.spotbugs>4.2.0</version.spotbugs>
+        <version.spotbugs>4.2.2</version.spotbugs>
+        <version.spotbugs.maven>4.2.2</version.spotbugs.maven>
         <version.surefire>3.0.0-M5</version.surefire>
     </properties>
 
@@ -398,6 +399,21 @@
 
         <plugins>
             <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>${version.spotbugs.maven}</version>
+                <dependencies>
+                  <!-- Overwrite dependency on SpotBugs if you want to specify the version of SpotBugs.
+                       SpotBugs itself is frequently several versions ahead of the spotbugs-maven-plugin -->
+                  <dependency>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs</artifactId>
+                    <version>${version.spotbugs}</version>
+                  </dependency>
+                </dependencies>
+            </plugin>
+
+            <plugin>
                 <groupId>net.sourceforge.maven-taglib</groupId>
                 <artifactId>maven-taglib-plugin</artifactId>
                 <version>2.4</version>
@@ -600,19 +616,19 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.14.0</version>
             </plugin>
 
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-project-info-reports-plugin</artifactId>
-               <version>3.1.0</version>
+               <version>3.1.1</version>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.0</version>
             </plugin>
 
             <plugin>
@@ -667,7 +683,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.7</version>
+                <version>2.8.1</version>
             </plugin>
 
             <plugin>
@@ -679,7 +695,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>5.3.2</version>
+                <version>6.1.3</version>
                 <configuration>
                     <failBuildOnCVSS>5.0</failBuildOnCVSS>
                     <suppressionFiles>./suppressions.xml</suppressionFiles>
@@ -807,7 +823,6 @@
               <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>${version.spotbugs}</version>
                 <configuration>
                     <plugins>
                         <plugin>

--- a/src/main/java/org/owasp/esapi/configuration/XmlEsapiPropertyLoader.java
+++ b/src/main/java/org/owasp/esapi/configuration/XmlEsapiPropertyLoader.java
@@ -104,20 +104,20 @@ public class XmlEsapiPropertyLoader extends AbstractPrioritizedPropertyLoader {
      * @throws ConfigurationException if there is a problem loading the specified configuration file.
      */
     protected void loadPropertiesFromFile(File file) throws ConfigurationException {
-        try {
-            validateAgainstXSD(new FileInputStream(file));
+        try ( InputStream configFile = new FileInputStream(file); ) {
+            validateAgainstXSD(configFile);
 
             DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance("org.apache.xerces.jaxp.DocumentBuilderFactoryImpl", null);
 System.out.println("DRW:DocumentBuilderFactory class: " + dbFactory.getClass()); // TODO: DEBUG-Delete Me
             dbFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 
             // Rest of these aren't needed really - TODO: Delete?
-            dbFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+/*            dbFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
             dbFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             dbFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
             dbFactory.setXIncludeAware(false);
             dbFactory.setExpandEntityReferences(false);
-
+*/
             DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
 System.out.println("DRW:DocumentBuilder class: " + dBuilder.getClass()); // TODO: DEBUG-Delete Me
             Document doc = dBuilder.parse(file);
@@ -135,18 +135,18 @@ System.out.println("DRW:DocumentBuilder class: " + dBuilder.getClass()); // TODO
             }
         } catch (IOException | SAXException | ParserConfigurationException e) {
             logSpecial("XML config file " + filename + " doesn't exist or has invalid schema", e);
-            throw new ConfigurationException("Configuration file : " + filename + " has invalid schema." + e.getMessage(), e);
+            throw new ConfigurationException("Configuration file : " + filename + " has invalid schema."
+                  + e.getMessage(), e);
         }
     }
 
     private void validateAgainstXSD(InputStream xml) throws IOException, SAXException {
-        InputStream xsd = getClass().getResourceAsStream("/ESAPI-properties.xsd");
-        SchemaFactory factory =
-                SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-        Schema schema = factory.newSchema(new StreamSource(xsd));
-        Validator validator = schema.newValidator();
-        validator.validate(new StreamSource(xml));
-        xml.close();
+        try ( InputStream xsd = getClass().getResourceAsStream("/ESAPI-properties.xsd"); ) {
+            SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+	        Schema schema = factory.newSchema(new StreamSource(xsd));
+	        Validator validator = schema.newValidator();
+	        validator.validate(new StreamSource(xml));
+        }
     }
 
 }

--- a/src/main/java/org/owasp/esapi/configuration/XmlEsapiPropertyLoader.java
+++ b/src/main/java/org/owasp/esapi/configuration/XmlEsapiPropertyLoader.java
@@ -108,18 +108,8 @@ public class XmlEsapiPropertyLoader extends AbstractPrioritizedPropertyLoader {
             validateAgainstXSD(configFile);
 
             DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance("org.apache.xerces.jaxp.DocumentBuilderFactoryImpl", null);
-System.out.println("DRW:DocumentBuilderFactory class: " + dbFactory.getClass()); // TODO: DEBUG-Delete Me
             dbFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-
-            // Rest of these aren't needed really - TODO: Delete?
-/*            dbFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            dbFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            dbFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-            dbFactory.setXIncludeAware(false);
-            dbFactory.setExpandEntityReferences(false);
-*/
             DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
-System.out.println("DRW:DocumentBuilder class: " + dBuilder.getClass()); // TODO: DEBUG-Delete Me
             Document doc = dBuilder.parse(file);
             doc.getDocumentElement().normalize();
 

--- a/src/main/java/org/owasp/esapi/configuration/XmlEsapiPropertyLoader.java
+++ b/src/main/java/org/owasp/esapi/configuration/XmlEsapiPropertyLoader.java
@@ -6,10 +6,12 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
@@ -99,13 +101,25 @@ public class XmlEsapiPropertyLoader extends AbstractPrioritizedPropertyLoader {
     /**
      * Methods loads configuration from .xml file. 
      * @param file
+     * @throws ConfigurationException if there is a problem loading the specified configuration file.
      */
     protected void loadPropertiesFromFile(File file) throws ConfigurationException {
         try {
             validateAgainstXSD(new FileInputStream(file));
 
-            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance("org.apache.xerces.jaxp.DocumentBuilderFactoryImpl", null);
+System.out.println("DRW:DocumentBuilderFactory class: " + dbFactory.getClass()); // TODO: DEBUG-Delete Me
+            dbFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+
+            // Rest of these aren't needed really - TODO: Delete?
+            dbFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            dbFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            dbFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            dbFactory.setXIncludeAware(false);
+            dbFactory.setExpandEntityReferences(false);
+
             DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+System.out.println("DRW:DocumentBuilder class: " + dBuilder.getClass()); // TODO: DEBUG-Delete Me
             Document doc = dBuilder.parse(file);
             doc.getDocumentElement().normalize();
 
@@ -119,19 +133,20 @@ public class XmlEsapiPropertyLoader extends AbstractPrioritizedPropertyLoader {
                     properties.put(propertyKey, propertyValue);
                 }
             }
-        } catch (Exception e) {
-            logSpecial("XML config file " + filename + " has invalid schema", e);
+        } catch (IOException | SAXException | ParserConfigurationException e) {
+            logSpecial("XML config file " + filename + " doesn't exist or has invalid schema", e);
             throw new ConfigurationException("Configuration file : " + filename + " has invalid schema." + e.getMessage(), e);
         }
     }
 
-    private void validateAgainstXSD(InputStream xml) throws Exception {
+    private void validateAgainstXSD(InputStream xml) throws IOException, SAXException {
         InputStream xsd = getClass().getResourceAsStream("/ESAPI-properties.xsd");
         SchemaFactory factory =
                 SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
         Schema schema = factory.newSchema(new StreamSource(xsd));
         Validator validator = schema.newValidator();
         validator.validate(new StreamSource(xml));
+        xml.close();
     }
 
 }


### PR DESCRIPTION
Upgrade a few libraries, add some used but undeclared libraries, and delete a bunch of declared/unused libraries. Also upgrade a bunch of plugins, and add support for using newer versions of SpotBugs even if the maven spotbugs plugin is a few versions behind the latest version of SpotBugs. Currently they are both at 4.2.2 but that isn't always the case.

This also addresses issue #614, by setting the proper security setting on an XML Parser Factory to disable an on-by-default feature that could allow an XXE exploit, but only from an insider attack against the ESAPI configuration file. While very unlikely, figured it's best to fix anyway. The referenced issue was opened after the pull request was created :-).