### PR TITLE
Logger Level Logic Updates

### DIFF
--- a/src/main/java/org/owasp/esapi/logging/java/JavaLogger.java
+++ b/src/main/java/org/owasp/esapi/logging/java/JavaLogger.java
@@ -24,7 +24,7 @@ public class JavaLogger implements org.owasp.esapi.Logger {
     /** Handler for translating events from ESAPI context for Java processing.*/
     private final JavaLogBridge logBridge;
     /** Maximum log level that will be forwarded to Java from the ESAPI context.*/
-    private int maxLogLevel;
+    private int loggingLevel;
 
     /**
      * Constructs a new instance. 
@@ -35,7 +35,7 @@ public class JavaLogger implements org.owasp.esapi.Logger {
     public JavaLogger(java.util.logging.Logger JavaLogger, JavaLogBridge bridge, int defaultEsapiLevel) {
         delegate = JavaLogger;
         this.logBridge = bridge;
-        maxLogLevel = defaultEsapiLevel;
+        loggingLevel = defaultEsapiLevel;
     }
 
     private void log(int esapiLevel, EventType type, String message) {
@@ -52,8 +52,7 @@ public class JavaLogger implements org.owasp.esapi.Logger {
 
 
     private boolean isEnabled(int esapiLevel) {
-        //Are Logger.OFF and Logger.ALL reversed?  This should be simply the less than or equal to check...
-        return (esapiLevel <= maxLogLevel && maxLogLevel != Logger.OFF) || maxLogLevel == Logger.ALL;
+        return esapiLevel >= loggingLevel;
     }
 
     @Override
@@ -128,7 +127,7 @@ public class JavaLogger implements org.owasp.esapi.Logger {
 
     @Override
     public int getESAPILevel() {
-        return maxLogLevel;
+        return loggingLevel;
     }
 
     @Override
@@ -162,7 +161,7 @@ public class JavaLogger implements org.owasp.esapi.Logger {
 
     @Override
     public void setLevel(int level) {
-        maxLogLevel = level;
+        loggingLevel = level;
     }
 
 }

--- a/src/main/java/org/owasp/esapi/logging/log4j/Log4JLogger.java
+++ b/src/main/java/org/owasp/esapi/logging/log4j/Log4JLogger.java
@@ -25,7 +25,7 @@ public class Log4JLogger implements org.owasp.esapi.Logger {
     /** Handler for translating events from ESAPI context for SLF4J processing.*/
     private final Log4JLogBridge logBridge;
     /** Maximum log level that will be forwarded to SLF4J from the ESAPI context.*/
-    private int maxLogLevel;
+    private int loggingLevel;
 
     /**
      * Constructs a new instance. 
@@ -36,7 +36,7 @@ public class Log4JLogger implements org.owasp.esapi.Logger {
     public Log4JLogger(org.apache.log4j.Logger slf4JLogger, Log4JLogBridge bridge, int defaultEsapiLevel) {
         delegate = slf4JLogger;
         this.logBridge = bridge;
-        maxLogLevel = defaultEsapiLevel;
+        loggingLevel = defaultEsapiLevel;
     }
 
     private void log(int esapiLevel, EventType type, String message) {
@@ -53,8 +53,7 @@ public class Log4JLogger implements org.owasp.esapi.Logger {
 
 
     private boolean isEnabled(int esapiLevel) {
-        //Are Logger.OFF and Logger.ALL reversed?  This should be simply the less than or equal to check...
-        return (esapiLevel <= maxLogLevel && maxLogLevel != Logger.OFF) || maxLogLevel == Logger.ALL;
+        return esapiLevel >= loggingLevel;
     }
 
     @Override
@@ -129,7 +128,7 @@ public class Log4JLogger implements org.owasp.esapi.Logger {
 
     @Override
     public int getESAPILevel() {
-        return maxLogLevel;
+        return loggingLevel;
     }
 
     @Override
@@ -163,7 +162,7 @@ public class Log4JLogger implements org.owasp.esapi.Logger {
 
     @Override
     public void setLevel(int level) {
-        maxLogLevel = level;
+        loggingLevel = level;
     }
 
 }

--- a/src/main/java/org/owasp/esapi/logging/slf4j/Slf4JLogger.java
+++ b/src/main/java/org/owasp/esapi/logging/slf4j/Slf4JLogger.java
@@ -24,7 +24,7 @@ public class Slf4JLogger implements org.owasp.esapi.Logger {
     /** Handler for translating events from ESAPI context for SLF4J processing.*/
     private final Slf4JLogBridge logBridge;
     /** Maximum log level that will be forwarded to SLF4J from the ESAPI context.*/
-    private int maxLogLevel;
+    private int loggingLevel;
     
     /**
      * Constructs a new instance. 
@@ -35,7 +35,7 @@ public class Slf4JLogger implements org.owasp.esapi.Logger {
     public Slf4JLogger(org.slf4j.Logger slf4JLogger, Slf4JLogBridge bridge, int defaultEsapiLevel) {
         delegate = slf4JLogger;
         this.logBridge = bridge;
-        maxLogLevel = defaultEsapiLevel;
+        loggingLevel = defaultEsapiLevel;
     }
     
     private void log(int esapiLevel, EventType type, String message) {
@@ -52,8 +52,7 @@ public class Slf4JLogger implements org.owasp.esapi.Logger {
     
 
     private boolean isEnabled(int esapiLevel) {
-        //Are Logger.OFF and Logger.ALL reversed?  This should be simply the less than or equal to check...
-        return (esapiLevel <= maxLogLevel && maxLogLevel != Logger.OFF) || maxLogLevel == Logger.ALL;
+       return esapiLevel >= loggingLevel;
     }
     
     @Override
@@ -128,7 +127,7 @@ public class Slf4JLogger implements org.owasp.esapi.Logger {
     
     @Override
     public int getESAPILevel() {
-        return maxLogLevel;
+        return loggingLevel;
     }
     
     @Override
@@ -162,7 +161,7 @@ public class Slf4JLogger implements org.owasp.esapi.Logger {
 
     @Override
     public void setLevel(int level) {
-       maxLogLevel = level;
+       loggingLevel = level;
     }
     
 }

--- a/src/test/java/org/owasp/esapi/logging/java/JavaLoggerTest.java
+++ b/src/test/java/org/owasp/esapi/logging/java/JavaLoggerTest.java
@@ -46,12 +46,12 @@ public class JavaLoggerTest {
     public void testLevelEnablement() {
         testLogger.setLevel(Logger.INFO);
 
-        Assert.assertFalse(testLogger.isFatalEnabled());
-        Assert.assertFalse(testLogger.isErrorEnabled());
-        Assert.assertFalse(testLogger.isWarningEnabled());
+        Assert.assertTrue(testLogger.isFatalEnabled());
+        Assert.assertTrue(testLogger.isErrorEnabled());
+        Assert.assertTrue(testLogger.isWarningEnabled());
         Assert.assertTrue(testLogger.isInfoEnabled());
-        Assert.assertTrue(testLogger.isDebugEnabled());
-        Assert.assertTrue(testLogger.isTraceEnabled());
+        Assert.assertFalse(testLogger.isDebugEnabled());
+        Assert.assertFalse(testLogger.isTraceEnabled());
 
         Assert.assertEquals(Logger.INFO, testLogger.getESAPILevel());
     }

--- a/src/test/java/org/owasp/esapi/logging/log4j/Log4JLoggerTest.java
+++ b/src/test/java/org/owasp/esapi/logging/log4j/Log4JLoggerTest.java
@@ -36,12 +36,12 @@ public class Log4JLoggerTest {
     public void testLevelEnablement() {
         testLogger.setLevel(Logger.INFO);
 
-        Assert.assertFalse(testLogger.isFatalEnabled());
-        Assert.assertFalse(testLogger.isErrorEnabled());
-        Assert.assertFalse(testLogger.isWarningEnabled());
+        Assert.assertTrue(testLogger.isFatalEnabled());
+        Assert.assertTrue(testLogger.isErrorEnabled());
+        Assert.assertTrue(testLogger.isWarningEnabled());
         Assert.assertTrue(testLogger.isInfoEnabled());
-        Assert.assertTrue(testLogger.isDebugEnabled());
-        Assert.assertTrue(testLogger.isTraceEnabled());
+        Assert.assertFalse(testLogger.isDebugEnabled());
+        Assert.assertFalse(testLogger.isTraceEnabled());
 
         Assert.assertEquals(Logger.INFO, testLogger.getESAPILevel());
     }

--- a/src/test/java/org/owasp/esapi/logging/slf4j/Slf4JLoggerTest.java
+++ b/src/test/java/org/owasp/esapi/logging/slf4j/Slf4JLoggerTest.java
@@ -34,12 +34,12 @@ public class Slf4JLoggerTest {
     public void testLevelEnablement() {
         testLogger.setLevel(Logger.INFO);
         
-        Assert.assertFalse(testLogger.isFatalEnabled());
-        Assert.assertFalse(testLogger.isErrorEnabled());
-        Assert.assertFalse(testLogger.isWarningEnabled());
+        Assert.assertTrue(testLogger.isFatalEnabled());
+        Assert.assertTrue(testLogger.isErrorEnabled());
+        Assert.assertTrue(testLogger.isWarningEnabled());
         Assert.assertTrue(testLogger.isInfoEnabled());
-        Assert.assertTrue(testLogger.isDebugEnabled());
-        Assert.assertTrue(testLogger.isTraceEnabled());
+        Assert.assertFalse(testLogger.isDebugEnabled());
+        Assert.assertFalse(testLogger.isTraceEnabled());
         
         Assert.assertEquals(Logger.INFO, testLogger.getESAPILevel());
     }


### PR DESCRIPTION
Closes #630 

Tests updated to reflect desired results of `isEnabled` for each of the loggers.
Logic updated to inverse the evaluate such that the method parameter must be greater than or equal to the configured logging level.
The field `maxLogLevel` has been renamed to `loggingLevel`