### PR TITLE
Changes to close issue #679

### DIFF
--- a/configuration/esapi/ESAPI.properties
+++ b/configuration/esapi/ESAPI.properties
@@ -194,9 +194,6 @@ Encryptor.cipher_modes.combined_modes=GCM,CCM,IAPM,EAX,OCB,CWC
 # Additional cipher modes allowed for ESAPI 2.0 encryption. These
 # cipher modes are in _addition_ to those specified by the property
 # 'Encryptor.cipher_modes.combined_modes'.
-# Note: We will add support for streaming modes like CFB & OFB once
-# we add support for 'specified' to the property 'Encryptor.ChooseIVMethod'
-# (probably in ESAPI 2.1).
 # DISCUSS: Better name?
 Encryptor.cipher_modes.additional_allowed=CBC
 
@@ -223,36 +220,26 @@ Encryptor.EncryptionKeyLength=128
 Encryptor.MinEncryptionKeyLength=128
 
 # Because 2.x uses CBC mode by default, it requires an initialization vector (IV).
-# (All cipher modes except ECB require an IV.) There are two choices: we can either
-# use a fixed IV known to both parties or allow ESAPI to choose a random IV. While
-# the IV does not need to be hidden from adversaries, it is important that the
-# adversary not be allowed to choose it. Also, random IVs are generally much more
-# secure than fixed IVs. (In fact, it is essential that feed-back cipher modes
-# such as CFB and OFB use a different IV for each encryption with a given key so
-# in such cases, random IVs are much preferred. By default, ESAPI 2.0 uses random
-# IVs. If you wish to use 'fixed' IVs, set 'Encryptor.ChooseIVMethod=fixed' and
-# uncomment the Encryptor.fixedIV.
+# (All cipher modes except ECB require an IV.) Previously there were two choices: we can either
+# use a fixed IV known to both parties or allow ESAPI to choose a random IV. The
+# former was deprecated in ESAPI 2.2 and removed in ESAPI 2.3. It was not secure
+# because the Encryptor (as are all the other major ESAPI components) is a
+# singleton and thus the same IV would get reused each time. It was not a
+# well-thought out plan. (To do it correctly means we need to add a setIV() method
+# and get rid of the Encryptor singleton, thus it will not happen until 3.0.)
+# However, while the IV does not need to be hidden from adversaries, it is important that the
+# adversary not be allowed to choose it. Thus for now, ESAPI just chooses a random IV.
+# Originally there was plans to allow a developer to provide a class and method
+# name to define a custom static method to generate an IV, but that is just
+# trouble waiting to happen. Thus in effect, the ONLY acceptable property value
+# for this property is "random". In the not too distant future (possibly the
+# next release), I will be removing it, but for now I am leaving this and
+# checking for it so a ConfigurationException can be thrown if anyone using
+# ESAPI ignored the deprecation warning message and still has it set to "fixed".
 #
-# Valid values:		random|fixed|specified		'specified' not yet implemented; planned for 2.3
-#                                               'fixed' is deprecated as of 2.2
-#                                               and will be removed in 2.3.
+# Valid values:		random
 Encryptor.ChooseIVMethod=random
 
-
-# If you choose to use a fixed IV, then you must place a fixed IV here that
-# is known to all others who are sharing your secret key. The format should
-# be a hex string that is the same length as the cipher block size for the
-# cipher algorithm that you are using. The following is an *example* for AES
-# from an AES test vector for AES-128/CBC as described in:
-# NIST Special Publication 800-38A (2001 Edition)
-# "Recommendation for Block Cipher Modes of Operation".
-# (Note that the block size for AES is 16 bytes == 128 bits.)
-#
-#   @Deprecated -- fixed IVs are deprecated as of the 2.2 release and support
-#                  will be removed in the next release (tentatively, 2.3).
-#                  If you MUST use this, at least replace this IV with one
-#                  that your legacy application was using.
-Encryptor.fixedIV=0x000102030405060708090a0b0c0d0e0f
 
 # Whether or not CipherText should use a message authentication code (MAC) with it.
 # This prevents an adversary from altering the IV as well as allowing a more

--- a/documentation/esapi4java-core-2.0-symmetric-crypto-user-guide.html
+++ b/documentation/esapi4java-core-2.0-symmetric-crypto-user-guide.html
@@ -149,8 +149,9 @@ are ones that you would replace.</P>
 			compatibility with legacy or third party software. If set to
 			“fixed”, then the property Encryptor.fixedIV must also be
 			set to hex-encoded specific IV that you need to use.
-            <B>NOTE:</B> "fixed" is deprecated and will be removed by
-            release 2.3.
+            <B>NOTE:</B> "fixed" had been deprecated since 2.2.0.0 and finally
+            was removed for release 2.3.0.0. Using it in versions 2.3.0.0 or
+            later will result in a <code>ConfigurationException</code> being thrown.
             </FONT></P><P><FONT SIZE=2>
             <B>CAUTION:</B> While it is not required that the IV be kept
             secret, encryption relying on fixed IVs can lead to a known

--- a/src/main/java/org/owasp/esapi/SecurityConfiguration.java
+++ b/src/main/java/org/owasp/esapi/SecurityConfiguration.java
@@ -389,34 +389,21 @@ public interface SecurityConfiguration extends EsapiPropertyLoader {
      * fixed IVs, but the use of non-random IVs is inherently insecure,
      * especially for any supported cipher mode that is considered a streaming mode
      * (which is basically anything except CBC for modes that support require an IV).
-     * For this reason, 'fixed' is considered <b>deprecated</b> and will be
-     * removed during the next ESAPI point release (tentatively, 2.3).
-     * However, note that if a "fixed" IV is chosen, then the
-     * the value of this fixed IV must be specified as the property
-     * {@code Encryptor.fixedIV} and be of the appropriate length.
+     * For this reason, 'fixed' has now been removed (it was considered <b>deprecated</b>
+     * since release 2.2.0.0). An <b>ESAPI.properties</b> value of {@Code fixed} for the property
+     * {@Code Encryptor.ChooseIVMethod} will now result in a {@Code ConfigurationException}
+     * being thrown.
      * 
-     * @return A string specifying the IV type. Should be "random" or "fixed" (dereprected).
+     * @return A string specifying the IV type. Should be "random". Anything
+     * else should fail with a {@Code ConfigurationException} being thrown.
      * 
      * @see #getFixedIV()
      * @deprecated Use SecurityConfiguration.getStringProp("appropriate_esapi_prop_name") instead.
+     *             This method will be removed in a future release as it is now moot since
+     *             it can only legitimately have the single value of "random".
      */
 	@Deprecated
     String getIVType();
-    
-    /**
-     * If a "fixed" (i.e., static) Initialization Vector (IV) is to be used,
-     * this will return the IV value as a hex-encoded string.
-     * @return The fixed IV as a hex-encoded string.
-     * @deprecated Short term: use SecurityConfiguration.getByteArrayProp("appropriate_esapi_prop_name")
-     *             instead. Longer term: There will be a more general method in JavaEncryptor
-     *             to explicitly set an IV. This whole concept of a single fixed IV has
-     *             always been a kludge at best, as a concession to those who have used
-     *             a single fixed IV in the past to support legacy applications. This method will be
-     *             killed off in the next ESAPI point release (likely 2.3). It's time to put it to death
-     *             as it was never intended for production in the first place.
-     */
-	@Deprecated
-    String getFixedIV();
     
     /**
      * Return a {@code List} of strings of combined cipher modes that support

--- a/src/main/java/org/owasp/esapi/crypto/CipherText.java
+++ b/src/main/java/org/owasp/esapi/crypto/CipherText.java
@@ -320,11 +320,10 @@ public final class CipherText implements Serializable {
      * base64-encoding is performed.
      * <p>
      * If there is a need to store an encrypted value, say in a database, this
-     * is <i>not</i> the method you should use unless you are using a <i>fixed</i>
-     * IV or are planning on retrieving the IV and storing it somewhere separately
-     * (e.g., a different database column). If you are <i>not</i> using a fixed IV
-     * (which is <strong>highly</strong> discouraged), you should normally use
-     * {@link #getEncodedIVCipherText()} instead.
+     * is <i>not</i> the method you should use unless you are using are storing the
+     * IV separately (i.e., in a separate DB column), which doesn't make a lot of sense.
+     * Normally, you should prefer the method {@link #getEncodedIVCipherText()} instead as
+     * it will return the IV prepended to the ciphertext.
      * </p>
      * @see #getEncodedIVCipherText()
      */
@@ -338,11 +337,6 @@ public final class CipherText implements Serializable {
      * base64-encoding. If an IV is not used, then this method returns the same
      * value as {@link #getBase64EncodedRawCipherText()}.
      * <p>
-     * Generally, this is the method that you should use unless you only
-     * are using a fixed IV and a storing that IV separately, in which case
-     * using {@link #getBase64EncodedRawCipherText()} can reduce the storage
-     * overhead.
-     * </p>
      * @return The base64-encoded ciphertext or base64-encoded IV + ciphertext.
      * @see #getBase64EncodedRawCipherText()
      */
@@ -591,8 +585,8 @@ public final class CipherText implements Serializable {
 // TODO: FIXME: As per email from Jeff Walton to Kevin Wall dated 12/03/2013,
 //            this is not always true. E.g., for CCM, the IV length is supposed
 //            to be 7, 8,  7, 8, 9, 10, 11, 12, or 13 octets because of
-//            it's formatting function, the restof the octets used by the
-//            nonce/counter.
+//            it's formatting function, the rest of the octets are used by the
+//            nonce/counter. E.g., see RFCs 4309, 8750, and related RFCs.
                     throw new EncryptionException("Encryption failed -- bad parameters passed to encrypt",  // DISCUSS - also log? See below.
                                                   "IV length does not match cipher block size of " + getBlockSize());
             }

--- a/src/main/java/org/owasp/esapi/reference/crypto/JavaEncryptor.java
+++ b/src/main/java/org/owasp/esapi/reference/crypto/JavaEncryptor.java
@@ -464,25 +464,10 @@ public final class JavaEncryptor implements Encryptor {
                  IvParameterSpec ivSpec = null;
                  if ( ivType.equalsIgnoreCase("random") ) {
                      ivBytes = ESAPI.randomizer().getRandomBytes(encrypter.getBlockSize());
-                 } else if ( ivType.equalsIgnoreCase("fixed") ) {
-                     String fixedIVAsHex = ESAPI.securityConfiguration().getFixedIV();
-                     ivBytes = Hex.decode(fixedIVAsHex);
-                     /* FUTURE       } else if ( ivType.equalsIgnoreCase("specified")) {
-                            // FUTURE - TODO  - Create instance of specified class to use for IV generation and
-                            //                   use it to create the ivBytes. (The intent is to make sure that
-                            //                   1) IVs are never repeated for cipher modes like OFB and CFB, and
-                            //                   2) to screen for weak IVs for the particular cipher algorithm.
-                            //      In meantime, use 'random' for block cipher in feedback mode. Unlikely they will
-                            //      be repeated unless you are salting SecureRandom with same value each time. Anything
-                            //      monotonically increasing should be suitable, like a counter, but need to remember
-                            //      it across JVM restarts. Was thinking of using System.currentTimeMillis(). While
-                            //      it's not perfect it probably is good enough. Could even all (advanced) developers
-                            //      to define their own class to create a unique IV to allow them some choice, but
-                            //      definitely need to provide a safe, default implementation.
-                      */
                  } else {
-                     // TODO: Update to add 'specified' once that is supported and added above.
-                     throw new ConfigurationException("Property Encryptor.ChooseIVMethod must be set to 'random' or 'fixed'");
+                     // This really shouldn't happen here. Show catch it a few
+                     // lines above.
+                     throw new ConfigurationException("Property Encryptor.ChooseIVMethod must be set to 'random'.");
                  }
                  ivSpec = new IvParameterSpec(ivBytes);
                  cipherSpec.setIV(ivBytes);

--- a/src/test/java/org/owasp/esapi/SecurityConfigurationWrapper.java
+++ b/src/test/java/org/owasp/esapi/SecurityConfigurationWrapper.java
@@ -291,14 +291,6 @@ public class SecurityConfigurationWrapper implements SecurityConfiguration
 		return wrapped.getIVType();
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
-	// @Override
-	public String getFixedIV()
-	{
-		return wrapped.getFixedIV();
-	}
 
 	/**
 	 * {@inheritDoc}

--- a/src/test/java/org/owasp/esapi/crypto/CipherSpecTest.java
+++ b/src/test/java/org/owasp/esapi/crypto/CipherSpecTest.java
@@ -29,10 +29,7 @@ public class CipherSpecTest extends TestCase {
 	private byte[] myIV = null;
 
 	@Before public void setUp() throws Exception {
-			// This will throw ConfigurationException if IV type is not set to
-			// 'fixed', which it's not. (We have it set to 'random'.)
-		// myIV = Hex.decode( ESAPI.securityConfiguration().getFixedIV() );
-		myIV = Hex.decode( "0x000102030405060708090a0b0c0d0e0f" );
+		myIV = Hex.decode( "0x000102030405060708090a0b0c0d0e0f" ); // Any IV to test w/ will do.
 
 		dfltAESCipher   = Cipher.getInstance("AES");
 		dfltECBCipher   = Cipher.getInstance("AES/ECB/NoPadding");

--- a/src/test/java/org/owasp/esapi/reference/DefaultSecurityConfigurationTest.java
+++ b/src/test/java/org/owasp/esapi/reference/DefaultSecurityConfigurationTest.java
@@ -8,8 +8,10 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.regex.Pattern;
+import java.util.Properties;
 
 import org.junit.Test;
+
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.Logger;
 import org.owasp.esapi.SecurityConfiguration;
@@ -19,7 +21,7 @@ import org.owasp.esapi.reference.DefaultSecurityConfiguration.DefaultSearchPath;
 public class DefaultSecurityConfigurationTest {
 
 	private DefaultSecurityConfiguration createWithProperty(String key, String val) {
-		java.util.Properties properties = new java.util.Properties();
+		Properties properties = new Properties();
 		properties.setProperty(key, val);
 		return new DefaultSecurityConfiguration(properties);
 	}
@@ -34,7 +36,7 @@ public class DefaultSecurityConfigurationTest {
 	@Test
 	public void testGetLogImplementation() {
 		//test the default
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		assertEquals(DefaultSecurityConfiguration.DEFAULT_LOG_IMPLEMENTATION, secConf.getLogImplementation());
 		
 		final String expected = "TestLogger";
@@ -45,7 +47,7 @@ public class DefaultSecurityConfigurationTest {
 	@Test
 	public void testAuthenticationImplementation() {
 		//test the default
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		assertEquals(DefaultSecurityConfiguration.DEFAULT_AUTHENTICATION_IMPLEMENTATION, secConf.getAuthenticationImplementation());
 		
 		final String expected = "TestAuthentication";
@@ -56,7 +58,7 @@ public class DefaultSecurityConfigurationTest {
 	@Test
 	public void testEncoderImplementation() {
 		//test the default
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		assertEquals(DefaultSecurityConfiguration.DEFAULT_ENCODER_IMPLEMENTATION, secConf.getEncoderImplementation());
 		
 		final String expected = "TestEncoder";
@@ -67,7 +69,7 @@ public class DefaultSecurityConfigurationTest {
 	@Test
 	public void testAccessControlImplementation() {
 		//test the default
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		assertEquals(DefaultSecurityConfiguration.DEFAULT_ACCESS_CONTROL_IMPLEMENTATION, secConf.getAccessControlImplementation());
 		
 		final String expected = "TestAccessControl";
@@ -78,7 +80,7 @@ public class DefaultSecurityConfigurationTest {
 	@Test
 	public void testEncryptionImplementation() {
 		//test the default
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		assertEquals(DefaultSecurityConfiguration.DEFAULT_ENCRYPTION_IMPLEMENTATION, secConf.getEncryptionImplementation());
 		
 		final String expected = "TestEncryption";
@@ -89,7 +91,7 @@ public class DefaultSecurityConfigurationTest {
 	@Test
 	public void testIntrusionDetectionImplementation() {
 		//test the default
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		assertEquals(DefaultSecurityConfiguration.DEFAULT_INTRUSION_DETECTION_IMPLEMENTATION, secConf.getIntrusionDetectionImplementation());
 		
 		final String expected = "TestIntrusionDetection";
@@ -100,7 +102,7 @@ public class DefaultSecurityConfigurationTest {
 	@Test
 	public void testRandomizerImplementation() {
 		//test the default
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		assertEquals(DefaultSecurityConfiguration.DEFAULT_RANDOMIZER_IMPLEMENTATION, secConf.getRandomizerImplementation());
 		
 		final String expected = "TestRandomizer";
@@ -111,7 +113,7 @@ public class DefaultSecurityConfigurationTest {
 	@Test
 	public void testExecutorImplementation() {
 		//test the default
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		assertEquals(DefaultSecurityConfiguration.DEFAULT_EXECUTOR_IMPLEMENTATION, secConf.getExecutorImplementation());
 		
 		final String expected = "TestExecutor";
@@ -122,7 +124,7 @@ public class DefaultSecurityConfigurationTest {
 	@Test
 	public void testHTTPUtilitiesImplementation() {
 		//test the default
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		assertEquals(DefaultSecurityConfiguration.DEFAULT_HTTP_UTILITIES_IMPLEMENTATION, secConf.getHTTPUtilitiesImplementation());
 		
 		final String expected = "TestHTTPUtilities";
@@ -133,7 +135,7 @@ public class DefaultSecurityConfigurationTest {
 	@Test
 	public void testValidationImplementation() {
 		//test the default
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		assertEquals(DefaultSecurityConfiguration.DEFAULT_VALIDATOR_IMPLEMENTATION, secConf.getValidationImplementation());
 		
 		final String expected = "TestValidation";
@@ -144,7 +146,7 @@ public class DefaultSecurityConfigurationTest {
 	@Test
 	public void testGetEncryptionKeyLength() {
 		// test the default
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		assertEquals(128, secConf.getEncryptionKeyLength());
 		
 		final int expected = 256;
@@ -155,7 +157,7 @@ public class DefaultSecurityConfigurationTest {
 	@Test
 	public void testGetKDFPseudoRandomFunction() {
 		// test the default
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		assertEquals("HmacSHA256", secConf.getKDFPseudoRandomFunction());
 		
 		final String expected = "HmacSHA1";
@@ -166,7 +168,7 @@ public class DefaultSecurityConfigurationTest {
 	@Test
 	public void testGetMasterSalt() {
 		try {
-			DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+			DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 			secConf.getMasterSalt();
 			fail("Expected Exception not thrown");
 		}
@@ -176,7 +178,7 @@ public class DefaultSecurityConfigurationTest {
 		
 		final String salt = "53081";
 		final String property = ESAPI.encoder().encodeForBase64(salt.getBytes(), false);
-		java.util.Properties properties = new java.util.Properties();
+		Properties properties = new Properties();
 		properties.setProperty(DefaultSecurityConfiguration.MASTER_SALT, property);
 		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(properties);
 		assertEquals(salt, new String(secConf.getMasterSalt()));
@@ -184,7 +186,7 @@ public class DefaultSecurityConfigurationTest {
 	
 	@Test
 	public void testGetAllowedExecutables() {
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		java.util.List<String> allowedExecutables = secConf.getAllowedExecutables();
 		
 		//is this really what should be returned? what about an empty list?
@@ -192,7 +194,7 @@ public class DefaultSecurityConfigurationTest {
 		assertEquals("", allowedExecutables.get(0));
 		
 		
-		java.util.Properties properties = new java.util.Properties();
+		Properties properties = new Properties();
 		properties.setProperty(DefaultSecurityConfiguration.APPROVED_EXECUTABLES, String.valueOf("/bin/bzip2,/bin/diff, /bin/cvs"));
 		secConf = new DefaultSecurityConfiguration(properties);
 		allowedExecutables = secConf.getAllowedExecutables();
@@ -208,12 +210,12 @@ public class DefaultSecurityConfigurationTest {
 	@Test
 	public void testGetAllowedFileExtensions() {
 		
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		java.util.List<String> allowedFileExtensions = secConf.getAllowedFileExtensions();
 		assertFalse(allowedFileExtensions.isEmpty());
 		
 		
-		java.util.Properties properties = new java.util.Properties();
+		Properties properties = new Properties();
 		properties.setProperty(DefaultSecurityConfiguration.APPROVED_UPLOAD_EXTENSIONS, String.valueOf(".txt,.xml,.html,.png"));
 		secConf = new DefaultSecurityConfiguration(properties);
 		allowedFileExtensions = secConf.getAllowedFileExtensions();
@@ -223,7 +225,7 @@ public class DefaultSecurityConfigurationTest {
 	
 	@Test
 	public void testGetAllowedFileUploadSize() {
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		//assert that the default is of some reasonable size
 		assertTrue(secConf.getAllowedFileUploadSize() > (1024 * 100));
 		
@@ -235,11 +237,11 @@ public class DefaultSecurityConfigurationTest {
 	@Test
 	public void testGetParameterNames() {
 		//test the default
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		assertEquals("password", secConf.getPasswordParameterName());
 		assertEquals("username", secConf.getUsernameParameterName());
 		
-		java.util.Properties properties = new java.util.Properties();
+		Properties properties = new Properties();
 		properties.setProperty(DefaultSecurityConfiguration.PASSWORD_PARAMETER_NAME, "j_password");
 		properties.setProperty(DefaultSecurityConfiguration.USERNAME_PARAMETER_NAME, "j_username");
 		secConf = new DefaultSecurityConfiguration(properties);
@@ -250,7 +252,7 @@ public class DefaultSecurityConfigurationTest {
 	@Test
 	public void testGetEncryptionAlgorithm() {
 		//test the default
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		assertEquals("AES", secConf.getEncryptionAlgorithm());
 		
 		secConf = this.createWithProperty(DefaultSecurityConfiguration.ENCRYPTION_ALGORITHM, "3DES");
@@ -259,11 +261,11 @@ public class DefaultSecurityConfigurationTest {
 	
 	@Test
 	public void testGetCipherXProperties() {
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		assertEquals("AES/CBC/PKCS5Padding", secConf.getCipherTransformation());
 		//assertEquals("AES/CBC/PKCS5Padding", secConf.getC);
 		
-		java.util.Properties properties = new java.util.Properties();
+		Properties properties = new Properties();
 		properties.setProperty(DefaultSecurityConfiguration.CIPHER_TRANSFORMATION_IMPLEMENTATION, "Blowfish/CFB/ISO10126Padding");
 		secConf = new DefaultSecurityConfiguration(properties);
 		assertEquals("Blowfish/CFB/ISO10126Padding", secConf.getCipherTransformation());
@@ -274,47 +276,35 @@ public class DefaultSecurityConfigurationTest {
 		secConf.setCipherTransformation(null);//sets it back to default
 		assertEquals("Blowfish/CFB/ISO10126Padding", secConf.getCipherTransformation());
 	}
-	
+
+	// NOTE: When SecurityConfiguration.getIVType() is finally removed, this test can be as well.
 	@Test
 	public void testIV() {
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
-		assertEquals("random", secConf.getIVType());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
+		assertEquals("random", secConf.getIVType());    // Ensure that 'random' is the default type for getIVType().
+
+        Properties props = new Properties();
+        String ivType = null;
+        props.setProperty(DefaultSecurityConfiguration.IV_TYPE, "fixed");  // No longer supported.
+
+        secConf = new DefaultSecurityConfiguration( props );
 		try {
-			secConf.getFixedIV();
-			fail();
+			ivType = secConf.getIVType();    // This should now throw a Configuration Exception.
+			fail("Expected ConfigurationException to be thrown for " + DefaultSecurityConfiguration.IV_TYPE + "=" + ivType);
 		}
 		catch (ConfigurationException ce) {
 			assertNotNull(ce.getMessage());
 		}
 		
-		java.util.Properties properties = new java.util.Properties();
-		properties.setProperty(DefaultSecurityConfiguration.IV_TYPE, "fixed");
-		properties.setProperty(DefaultSecurityConfiguration.FIXED_IV, "ivValue");
-		secConf = new DefaultSecurityConfiguration(properties);
-		assertEquals("fixed", secConf.getIVType());
-		assertEquals("ivValue", secConf.getFixedIV());
-		
-		properties.setProperty(DefaultSecurityConfiguration.IV_TYPE, "illegal");
-		secConf = new DefaultSecurityConfiguration(properties);
-		try {
-			secConf.getIVType();
-			fail();
-		}
-		catch (ConfigurationException ce) {
-			assertNotNull(ce.getMessage());
-		}
-		try {
-			secConf.getFixedIV();
-			fail();
-		}
-		catch (ConfigurationException ce) {
-			assertNotNull(ce.getMessage());
-		}
+		props.setProperty(DefaultSecurityConfiguration.IV_TYPE, "illegal");	// This will just result in a logSpecial message & "random" is returned.
+		secConf = new DefaultSecurityConfiguration(props);
+		ivType = secConf.getIVType();
+		assertEquals(ivType, "random");
 	}
 	
 	@Test
 	public void testGetAllowMultipleEncoding() {
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		assertFalse(secConf.getAllowMultipleEncoding());
 		
 		secConf = this.createWithProperty(DefaultSecurityConfiguration.ALLOW_MULTIPLE_ENCODING, "yes");
@@ -329,7 +319,7 @@ public class DefaultSecurityConfigurationTest {
 	
 	@Test
 	public void testGetDefaultCanonicalizationCodecs() {
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		assertFalse(secConf.getDefaultCanonicalizationCodecs().isEmpty());
 		
 		String property = "org.owasp.esapi.codecs.TestCodec1,org.owasp.esapi.codecs.TestCodec2";
@@ -339,7 +329,7 @@ public class DefaultSecurityConfigurationTest {
 	
 	@Test
 	public void testGetDisableIntrusionDetection() {
-		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new java.util.Properties());
+		DefaultSecurityConfiguration secConf = new DefaultSecurityConfiguration(new Properties());
 		assertFalse(secConf.getDisableIntrusionDetection());
 		
 		secConf = this.createWithProperty(DefaultSecurityConfiguration.DISABLE_INTRUSION_DETECTION, "TRUE");

--- a/src/test/resources/esapi/ESAPI-CommaValidatorFileChecker.properties
+++ b/src/test/resources/esapi/ESAPI-CommaValidatorFileChecker.properties
@@ -259,9 +259,6 @@ Encryptor.cipher_modes.combined_modes=GCM,CCM,IAPM,EAX,OCB,CWC
 # Additional cipher modes allowed for ESAPI 2.0 encryption. These
 # cipher modes are in _addition_ to those specified by the property
 # 'Encryptor.cipher_modes.combined_modes'.
-# Note: We will add support for streaming modes like CFB & OFB once
-# we add support for 'specified' to the property 'Encryptor.ChooseIVMethod'
-# (probably in ESAPI 2.1).
 #
 #	IMPORTANT NOTE:	In the official ESAPI.properties we do *NOT* include ECB
 #					here as this is an extremely weak mode. However, we *must*
@@ -284,29 +281,26 @@ Encryptor.EncryptionKeyLength=128
 # Min key length - to support testing with 2TDEA
 Encryptor.MinEncryptionKeyLength=112
 
-# Because 2.0 uses CBC mode by default, it requires an initialization vector (IV).
-# (All cipher modes except ECB require an IV.) There are two choices: we can either
-# use a fixed IV known to both parties or allow ESAPI to choose a random IV. While
-# the IV does not need to be hidden from adversaries, it is important that the
-# adversary not be allowed to choose it. Also, random IVs are generally much more
-# secure than fixed IVs. (In fact, it is essential that feed-back cipher modes
-# such as CFB and OFB use a different IV for each encryption with a given key so
-# in such cases, random IVs are much preferred. By default, ESAPI 2.0 uses random
-# IVs. If you wish to use 'fixed' IVs, set 'Encryptor.ChooseIVMethod=fixed' and
-# uncomment the Encryptor.fixedIV.
+# Because 2.x uses CBC mode by default, it requires an initialization vector (IV).
+# (All cipher modes except ECB require an IV.) Previously there were two choices: we can either
+# use a fixed IV known to both parties or allow ESAPI to choose a random IV. The
+# former was deprecated in ESAPI 2.2 and removed in ESAPI 2.3. It was not secure
+# because the Encryptor (as are all the other major ESAPI components) is a
+# singleton and thus the same IV would get reused each time. It was not a
+# well-thought out plan. (To do it correctly means we need to add a setIV() method
+# and get rid of the Encryptor singleton, thus it will not happen until 3.0.)
+# However, while the IV does not need to be hidden from adversaries, it is important that the
+# adversary not be allowed to choose it. Thus for now, ESAPI just chooses a random IV.
+# Originally there was plans to allow a developer to provide a class and method
+# name to define a custom static method to generate an IV, but that is just
+# trouble waiting to happen. Thus in effect, the ONLY acceptable property value
+# for this property is "random". In the not too distant future (possibly the
+# next release), I will be removing it, but for now I am leaving this and
+# checking for it so a ConfigurationException can be thrown if anyone using
+# ESAPI ignored the deprecation warning message and still has it set to "fixed".
 #
-# Valid values:		random|fixed|specified		'specified' not yet implemented; planned for 2.1
+# Valid values:		random
 Encryptor.ChooseIVMethod=random
-# If you choose to use a fixed IV, then you must place a fixed IV here that
-# is known to all others who are sharing your secret key. The format should
-# be a hex string that is the same length as the cipher block size for the
-# cipher algorithm that you are using. The following is an example for AES
-# from an AES test vector for AES-128/CBC as described in:
-# NIST Special Publication 800-38A (2001 Edition)
-# "Recommendation for Block Cipher Modes of Operation".
-# (Note that the block size for AES is 16 bytes == 128 bits.)
-#
-Encryptor.fixedIV=0x000102030405060708090a0b0c0d0e0f
 
 # Whether or not CipherText should use a message authentication code (MAC) with it.
 # This prevents an adversary from altering the IV as well as allowing a more

--- a/src/test/resources/esapi/ESAPI-DualValidatorFileChecker.properties
+++ b/src/test/resources/esapi/ESAPI-DualValidatorFileChecker.properties
@@ -259,9 +259,6 @@ Encryptor.cipher_modes.combined_modes=GCM,CCM,IAPM,EAX,OCB,CWC
 # Additional cipher modes allowed for ESAPI 2.0 encryption. These
 # cipher modes are in _addition_ to those specified by the property
 # 'Encryptor.cipher_modes.combined_modes'.
-# Note: We will add support for streaming modes like CFB & OFB once
-# we add support for 'specified' to the property 'Encryptor.ChooseIVMethod'
-# (probably in ESAPI 2.1).
 #
 #	IMPORTANT NOTE:	In the official ESAPI.properties we do *NOT* include ECB
 #					here as this is an extremely weak mode. However, we *must*
@@ -285,29 +282,26 @@ Encryptor.EncryptionKeyLength=128
 # Min key length - to support testing with 2TDEA
 Encryptor.MinEncryptionKeyLength=112
 
-# Because 2.0 uses CBC mode by default, it requires an initialization vector (IV).
-# (All cipher modes except ECB require an IV.) There are two choices: we can either
-# use a fixed IV known to both parties or allow ESAPI to choose a random IV. While
-# the IV does not need to be hidden from adversaries, it is important that the
-# adversary not be allowed to choose it. Also, random IVs are generally much more
-# secure than fixed IVs. (In fact, it is essential that feed-back cipher modes
-# such as CFB and OFB use a different IV for each encryption with a given key so
-# in such cases, random IVs are much preferred. By default, ESAPI 2.0 uses random
-# IVs. If you wish to use 'fixed' IVs, set 'Encryptor.ChooseIVMethod=fixed' and
-# uncomment the Encryptor.fixedIV.
+# Because 2.x uses CBC mode by default, it requires an initialization vector (IV).
+# (All cipher modes except ECB require an IV.) Previously there were two choices: we can either
+# use a fixed IV known to both parties or allow ESAPI to choose a random IV. The
+# former was deprecated in ESAPI 2.2 and removed in ESAPI 2.3. It was not secure
+# because the Encryptor (as are all the other major ESAPI components) is a
+# singleton and thus the same IV would get reused each time. It was not a
+# well-thought out plan. (To do it correctly means we need to add a setIV() method
+# and get rid of the Encryptor singleton, thus it will not happen until 3.0.)
+# However, while the IV does not need to be hidden from adversaries, it is important that the
+# adversary not be allowed to choose it. Thus for now, ESAPI just chooses a random IV.
+# Originally there was plans to allow a developer to provide a class and method
+# name to define a custom static method to generate an IV, but that is just
+# trouble waiting to happen. Thus in effect, the ONLY acceptable property value
+# for this property is "random". In the not too distant future (possibly the
+# next release), I will be removing it, but for now I am leaving this and
+# checking for it so a ConfigurationException can be thrown if anyone using
+# ESAPI ignored the deprecation warning message and still has it set to "fixed".
 #
-# Valid values:		random|fixed|specified		'specified' not yet implemented; planned for 2.1
+# Valid values:		random
 Encryptor.ChooseIVMethod=random
-# If you choose to use a fixed IV, then you must place a fixed IV here that
-# is known to all others who are sharing your secret key. The format should
-# be a hex string that is the same length as the cipher block size for the
-# cipher algorithm that you are using. The following is an example for AES
-# from an AES test vector for AES-128/CBC as described in:
-# NIST Special Publication 800-38A (2001 Edition)
-# "Recommendation for Block Cipher Modes of Operation".
-# (Note that the block size for AES is 16 bytes == 128 bits.)
-#
-Encryptor.fixedIV=0x000102030405060708090a0b0c0d0e0f
 
 # Whether or not CipherText should use a message authentication code (MAC) with it.
 # This prevents an adversary from altering the IV as well as allowing a more

--- a/src/test/resources/esapi/ESAPI-QuotedValidatorFileChecker.properties
+++ b/src/test/resources/esapi/ESAPI-QuotedValidatorFileChecker.properties
@@ -258,9 +258,6 @@ Encryptor.cipher_modes.combined_modes=GCM,CCM,IAPM,EAX,OCB,CWC
 # Additional cipher modes allowed for ESAPI 2.0 encryption. These
 # cipher modes are in _addition_ to those specified by the property
 # 'Encryptor.cipher_modes.combined_modes'.
-# Note: We will add support for streaming modes like CFB & OFB once
-# we add support for 'specified' to the property 'Encryptor.ChooseIVMethod'
-# (probably in ESAPI 2.1).
 #
 #	IMPORTANT NOTE:	In the official ESAPI.properties we do *NOT* include ECB
 #					here as this is an extremely weak mode. However, we *must*
@@ -283,29 +280,26 @@ Encryptor.EncryptionKeyLength=128
 # Min key length - to support testing with 2TDEA
 Encryptor.MinEncryptionKeyLength=112
 
-# Because 2.0 uses CBC mode by default, it requires an initialization vector (IV).
-# (All cipher modes except ECB require an IV.) There are two choices: we can either
-# use a fixed IV known to both parties or allow ESAPI to choose a random IV. While
-# the IV does not need to be hidden from adversaries, it is important that the
-# adversary not be allowed to choose it. Also, random IVs are generally much more
-# secure than fixed IVs. (In fact, it is essential that feed-back cipher modes
-# such as CFB and OFB use a different IV for each encryption with a given key so
-# in such cases, random IVs are much preferred. By default, ESAPI 2.0 uses random
-# IVs. If you wish to use 'fixed' IVs, set 'Encryptor.ChooseIVMethod=fixed' and
-# uncomment the Encryptor.fixedIV.
+# Because 2.x uses CBC mode by default, it requires an initialization vector (IV).
+# (All cipher modes except ECB require an IV.) Previously there were two choices: we can either
+# use a fixed IV known to both parties or allow ESAPI to choose a random IV. The
+# former was deprecated in ESAPI 2.2 and removed in ESAPI 2.3. It was not secure
+# because the Encryptor (as are all the other major ESAPI components) is a
+# singleton and thus the same IV would get reused each time. It was not a
+# well-thought out plan. (To do it correctly means we need to add a setIV() method
+# and get rid of the Encryptor singleton, thus it will not happen until 3.0.)
+# However, while the IV does not need to be hidden from adversaries, it is important that the
+# adversary not be allowed to choose it. Thus for now, ESAPI just chooses a random IV.
+# Originally there was plans to allow a developer to provide a class and method
+# name to define a custom static method to generate an IV, but that is just
+# trouble waiting to happen. Thus in effect, the ONLY acceptable property value
+# for this property is "random". In the not too distant future (possibly the
+# next release), I will be removing it, but for now I am leaving this and
+# checking for it so a ConfigurationException can be thrown if anyone using
+# ESAPI ignored the deprecation warning message and still has it set to "fixed".
 #
-# Valid values:		random|fixed|specified		'specified' not yet implemented; planned for 2.1
+# Valid values:		random
 Encryptor.ChooseIVMethod=random
-# If you choose to use a fixed IV, then you must place a fixed IV here that
-# is known to all others who are sharing your secret key. The format should
-# be a hex string that is the same length as the cipher block size for the
-# cipher algorithm that you are using. The following is an example for AES
-# from an AES test vector for AES-128/CBC as described in:
-# NIST Special Publication 800-38A (2001 Edition)
-# "Recommendation for Block Cipher Modes of Operation".
-# (Note that the block size for AES is 16 bytes == 128 bits.)
-#
-Encryptor.fixedIV=0x000102030405060708090a0b0c0d0e0f
 
 # Whether or not CipherText should use a message authentication code (MAC) with it.
 # This prevents an adversary from altering the IV as well as allowing a more

--- a/src/test/resources/esapi/ESAPI-SingleValidatorFileChecker.properties
+++ b/src/test/resources/esapi/ESAPI-SingleValidatorFileChecker.properties
@@ -258,9 +258,6 @@ Encryptor.cipher_modes.combined_modes=GCM,CCM,IAPM,EAX,OCB,CWC
 # Additional cipher modes allowed for ESAPI 2.0 encryption. These
 # cipher modes are in _addition_ to those specified by the property
 # 'Encryptor.cipher_modes.combined_modes'.
-# Note: We will add support for streaming modes like CFB & OFB once
-# we add support for 'specified' to the property 'Encryptor.ChooseIVMethod'
-# (probably in ESAPI 2.1).
 #
 #	IMPORTANT NOTE:	In the official ESAPI.properties we do *NOT* include ECB
 #					here as this is an extremely weak mode. However, we *must*
@@ -283,29 +280,26 @@ Encryptor.EncryptionKeyLength=128
 # Min key length - to support testing with 2TDEA
 Encryptor.MinEncryptionKeyLength=112
 
-# Because 2.0 uses CBC mode by default, it requires an initialization vector (IV).
-# (All cipher modes except ECB require an IV.) There are two choices: we can either
-# use a fixed IV known to both parties or allow ESAPI to choose a random IV. While
-# the IV does not need to be hidden from adversaries, it is important that the
-# adversary not be allowed to choose it. Also, random IVs are generally much more
-# secure than fixed IVs. (In fact, it is essential that feed-back cipher modes
-# such as CFB and OFB use a different IV for each encryption with a given key so
-# in such cases, random IVs are much preferred. By default, ESAPI 2.0 uses random
-# IVs. If you wish to use 'fixed' IVs, set 'Encryptor.ChooseIVMethod=fixed' and
-# uncomment the Encryptor.fixedIV.
+# Because 2.x uses CBC mode by default, it requires an initialization vector (IV).
+# (All cipher modes except ECB require an IV.) Previously there were two choices: we can either
+# use a fixed IV known to both parties or allow ESAPI to choose a random IV. The
+# former was deprecated in ESAPI 2.2 and removed in ESAPI 2.3. It was not secure
+# because the Encryptor (as are all the other major ESAPI components) is a
+# singleton and thus the same IV would get reused each time. It was not a
+# well-thought out plan. (To do it correctly means we need to add a setIV() method
+# and get rid of the Encryptor singleton, thus it will not happen until 3.0.)
+# However, while the IV does not need to be hidden from adversaries, it is important that the
+# adversary not be allowed to choose it. Thus for now, ESAPI just chooses a random IV.
+# Originally there was plans to allow a developer to provide a class and method
+# name to define a custom static method to generate an IV, but that is just
+# trouble waiting to happen. Thus in effect, the ONLY acceptable property value
+# for this property is "random". In the not too distant future (possibly the
+# next release), I will be removing it, but for now I am leaving this and
+# checking for it so a ConfigurationException can be thrown if anyone using
+# ESAPI ignored the deprecation warning message and still has it set to "fixed".
 #
-# Valid values:		random|fixed|specified		'specified' not yet implemented; planned for 2.1
+# Valid values:		random
 Encryptor.ChooseIVMethod=random
-# If you choose to use a fixed IV, then you must place a fixed IV here that
-# is known to all others who are sharing your secret key. The format should
-# be a hex string that is the same length as the cipher block size for the
-# cipher algorithm that you are using. The following is an example for AES
-# from an AES test vector for AES-128/CBC as described in:
-# NIST Special Publication 800-38A (2001 Edition)
-# "Recommendation for Block Cipher Modes of Operation".
-# (Note that the block size for AES is 16 bytes == 128 bits.)
-#
-Encryptor.fixedIV=0x000102030405060708090a0b0c0d0e0f
 
 # Whether or not CipherText should use a message authentication code (MAC) with it.
 # This prevents an adversary from altering the IV as well as allowing a more

--- a/src/test/resources/esapi/ESAPI.properties
+++ b/src/test/resources/esapi/ESAPI.properties
@@ -239,9 +239,6 @@ Encryptor.cipher_modes.combined_modes=GCM,CCM,IAPM,EAX,OCB,CWC
 # Additional cipher modes allowed for ESAPI 2.0 encryption. These
 # cipher modes are in _addition_ to those specified by the property
 # 'Encryptor.cipher_modes.combined_modes'.
-# Note: We will add support for streaming modes like CFB & OFB once
-# we add support for 'specified' to the property 'Encryptor.ChooseIVMethod'
-# (probably in ESAPI 2.1).
 #
 #	IMPORTANT NOTE:	In the official ESAPI.properties we do *NOT* include ECB
 #					here as this is an extremely weak mode. However, we *must*
@@ -275,36 +272,25 @@ Encryptor.EncryptionKeyLength=128
 Encryptor.MinEncryptionKeyLength=112
 
 # Because 2.x uses CBC mode by default, it requires an initialization vector (IV).
-# (All cipher modes except ECB require an IV.) There are two choices: we can either
-# use a fixed IV known to both parties or allow ESAPI to choose a random IV. While
-# the IV does not need to be hidden from adversaries, it is important that the
-# adversary not be allowed to choose it. Also, random IVs are generally much more
-# secure than fixed IVs. (In fact, it is essential that feed-back cipher modes
-# such as CFB and OFB use a different IV for each encryption with a given key so
-# in such cases, random IVs are much preferred. By default, ESAPI 2.0 uses random
-# IVs. If you wish to use 'fixed' IVs, set 'Encryptor.ChooseIVMethod=fixed' and
-# uncomment the Encryptor.fixedIV.
+# (All cipher modes except ECB require an IV.) Previously there were two choices: we can either
+# use a fixed IV known to both parties or allow ESAPI to choose a random IV. The
+# former was deprecated in ESAPI 2.2 and removed in ESAPI 2.3. It was not secure
+# because the Encryptor (as are all the other major ESAPI components) is a
+# singleton and thus the same IV would get reused each time. It was not a
+# well-thought out plan. (To do it correctly means we need to add a setIV() method
+# and get rid of the Encryptor singleton, thus it will not happen until 3.0.)
+# However, while the IV does not need to be hidden from adversaries, it is important that the
+# adversary not be allowed to choose it. Thus for now, ESAPI just chooses a random IV.
+# Originally there was plans to allow a developer to provide a class and method
+# name to define a custom static method to generate an IV, but that is just
+# trouble waiting to happen. Thus in effect, the ONLY acceptable property value
+# for this property is "random". In the not too distant future (possibly the
+# next release), I will be removing it, but for now I am leaving this and
+# checking for it so a ConfigurationException can be thrown if anyone using
+# ESAPI ignored the deprecation warning message and still has it set to "fixed".
 #
-# Valid values:		random|fixed|specified		'specified' not yet implemented; planned for 2.3
-#                                               'fixed' is deprecated as of 2.2
-#                                               and will be removed in 2.3.
+# Valid values:		random
 Encryptor.ChooseIVMethod=random
-
-
-# If you choose to use a fixed IV, then you must place a fixed IV here that
-# is known to all others who are sharing your secret key. The format should
-# be a hex string that is the same length as the cipher block size for the
-# cipher algorithm that you are using. The following is an *example* for AES
-# from an AES test vector for AES-128/CBC as described in:
-# NIST Special Publication 800-38A (2001 Edition)
-# "Recommendation for Block Cipher Modes of Operation".
-# (Note that the block size for AES is 16 bytes == 128 bits.)
-#
-#   @Deprecated -- fixed IVs are deprecated as of the 2.2 release and support
-#                  will be removed in the next release (tentatively, 2.3).
-#                  If you MUST use this, at least replace this IV with one
-#                  that your legacy application was using.
-Encryptor.fixedIV=0x000102030405060708090a0b0c0d0e0f
 
 # Whether or not CipherText should use a message authentication code (MAC) with it.
 # This prevents an adversary from altering the IV as well as allowing a more


### PR DESCRIPTION
@xeno6696 or @jeremiahjstacey -- these changes are not really as much crypto-related (other than the _reason_ why I'm making them), as the are related to the ESAPI `SecurityConfiguration` component.

I originally had them in the otherwise small updates to prep the next release (which I am actually going to call 2.3.0.0 rather than 2.2.4.0, so I can finally justify dumping this whole bad "fixed IV" idea. (Thought up in the days where I was emphasizing backward compatibility and supporting legacy code over security, Sigh. Well, guess that means I learned _something_ in the past 10 plus years.)

Anyhow, could I get one of you to do a quick and dirty code review and them merge this? Pending my email to Sebastian and Dave, I'd like to get this merged by early tomorrow evening so I can get it into the release. Thanks!

P.S.- I assigned _both_ of you as code reviewers, but that doesn't mean that you both really need to look at it. There is actually a LOT more cleanup that I can do, but I don't want to shock people too much and remove functionality that would actually keep code from compiling, which is why I've left the deprecated SecurityConfiguration.getIVType() for now, but it's pointless now that I've changed the code to only allow a single valid value.