### PR TITLE
Plugin & Dependency Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	    <version.jmh>1.35</version.jmh>
         <version.powermock>2.0.9</version.powermock>
-        <version.spotbugs>4.6.0</version.spotbugs>
+        <version.spotbugs>4.7.0</version.spotbugs>
         <version.findsecbugs>1.12.0</version.findsecbugs>
         <version.spotbugs.maven>4.6.0.0</version.spotbugs.maven>
         <version.surefire>3.0.0-M6</version.surefire>

--- a/pom.xml
+++ b/pom.xml
@@ -677,7 +677,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-project-info-reports-plugin</artifactId>
-               <version>3.2.2</version>
+               <version>3.3.0</version>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -689,7 +689,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
-                <version>3.12.0</version>
+                <version>4.0.0-M1</version>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
Closes #690 
```
  maven-project-info-reports-plugin .................. 3.2.2 -> 3.3.0
  maven-site-plugin .............................. 3.12.0 -> 4.0.0-M1
  com.github.spotbugs:spotbugs-annotations .............. 4.6.0 -> 4.7.0
  com.github.spotbugs:spotbugs .......................... 4.6.0 -> 4.7.0
```
`mvn clean package` and `mvn site:site` complete successfully