### PR TITLE
Log4j loose ends

### DIFF
--- a/documentation/LoggerDesignAndTesting.md
+++ b/documentation/LoggerDesignAndTesting.md
@@ -22,6 +22,6 @@ The general workflow is:
 
     Logger.info/warn/etc(message) -> forwards to LogBridgelog(logger, esapiLevel, type, message) -> forwards to LogHandler.log(...) -> forwards to slf4j Logger implementation with appropriate level and composed message.
 
-So each of the tests for each of the classes verifies data in -> data out based on the Logging API.  The structure for JUL, Log4J, and SLF4J are almost identical.  There are a few differences in the interaction with the underlying Logger interactions and expectations.  As a result, the tests are also almost full duplications (again accounting for differences in the underlying logging API).
+So each of the tests for each of the classes verifies data in -> data out based on the Logging API.  The structure for JUL and SLF4J are almost identical.  There are a few differences in the interaction with the underlying Logger interactions and expectations.  As a result, the tests are also almost full duplications (again accounting for differences in the underlying logging API).
 
 -J

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <version.powermock>2.0.9</version.powermock>
         <version.spotbugs>4.7.1</version.spotbugs>
         <version.findsecbugs>1.12.0</version.findsecbugs>
-        <version.spotbugs.maven>4.7.0.0</version.spotbugs.maven>
+        <version.spotbugs.maven>4.7.1.0</version.spotbugs.maven>
         <version.surefire>3.0.0-M7</version.surefire>
         <project.java.target>1.8</project.java.target>
             <!-- TODO: Be sure to update. Should be date of previous official release -->
@@ -406,7 +406,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.4.0</version>
+                    <version>3.4.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -538,7 +538,7 @@
                   <dependency>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>extra-enforcer-rules</artifactId>
-                    <version>1.5.1</version>
+                    <version>1.6.0</version>
                   </dependency>
                   <dependency>
                     <groupId>org.codehaus.mojo</groupId>

--- a/scripts/esapi-release.sh
+++ b/scripts/esapi-release.sh
@@ -64,8 +64,8 @@ USAGE="Usage: $PROG esapi_svn_dir"
 tmpdir="/tmp/$PROG.$RANDOM-$$"
 esapi_release_dir="$tmpdir/esapi_release_dir"
 
-    # This is the directory under esapi_svn_dir where the log4j and ESAPI
-    # properties files are located as well as the $esapiConfig/* config files.
+    # This is the directory under esapi_svn_dir where ESAPI configuration files
+    # such as ESAPI.properties are located as well as the $esapiConfig/* config files.
     # Note that formerly used to be under src/main/resources, but it since
     # has been moved because where it was previously was causing problems with
     # Sonatype's Nexus. That particular problem may have been resolved, but it
@@ -141,7 +141,7 @@ mkdir $jartmpdir
 cd $jartmpdir || exit
 jar xf "$jarfile"
 rm -fr ${esapiConfig:?}
-rm -f properties/* log4j.*
+rm -f properties/*
 rm -f settings.xml owasp-esapi-dev.jks
 # TODO: This part would need some work if we sign or seal the ESAPI jar as
 #       that creates a special MANIFEST.MF file and other special files and

--- a/scripts/esapi4java-core-TEMPLATE-release-notes.txt
+++ b/scripts/esapi4java-core-TEMPLATE-release-notes.txt
@@ -51,7 +51,7 @@ Issue #         GitHub Issue Title
 @@@@ NOTE any special notes here. Probably leave this one, but I would suggest noting additions BEFORE this.
 [If you have already successfully been using ESAPI 2.2.1.0 or later, you probably can skip this section.]
 
-Since ESAPI 2.2.1.0, the new default ESAPI logger is JUL (java.util.logging packages) and we have deprecated the use of Log4J 1.x because we now support SLF4J and Log4J 1.x is way past its end-of-life. We did not want to make SLF4J the default logger (at least not yet) as we did not want to have the default ESAPI use require additional dependencies. However, SLF4J is likely to be the future choice, at least once we start on ESAPI 3.0. A special shout-out to Jeremiah Stacey for making this possible by re-factoring much of the ESAPI logger code. Note, the straw that broke the proverbial camel's back was the announcement of CVE-2019-17571 (rated Critical), for which there is no fix available and likely will never be.
+Since ESAPI 2.2.1.0, the new default ESAPI logger is JUL (java.util.logging packages) and we had deprecated the use of Log4J 1.x because was way past its end-of-life. (Note: As of ESAPI 2.5.0.0, we have officially removed all Log4J 1 dependencies, after it had been deprecated for 2 years as per our deprecation policy.) We did not want to make SLF4J the default logger (at least not yet) as we did not want to have the default ESAPI use require additional dependencies. However, SLF4J is likely to be the future choice, at least once we start on ESAPI 3.0. A special shout-out to Jeremiah Stacey for making this possible by re-factoring much of the ESAPI logger code. Note, the straw that broke the proverbial camel's back was the announcement of CVE-2019-17571 (rated Critical), for which there is no fix available and likely will never be.
 
 However, if you try to juse the new ESAPI 2.2.1.0 or later logging you will notice that you need to change ESAPI.Logger and also possibly provide some other properties as well to get the logging behavior that you desire.
 
@@ -85,11 +85,6 @@ If you are using JavaLogFactory, you will also want to ensure that you have the 
     Logger.ClientInfo=true
 
 See GitHub issue #560 for additional details.
-
-
-Related to that aforemented Log4J 1.x CVE and how it affects ESAPI, be sure to read
-   https://github.com/ESAPI/esapi-java-legacy/blob/develop/documentation/ESAPI-security-bulletin2.pdf 
-which describes CVE-2019-17571, a deserialization vulnerability in Log4J 1.2.17. ESAPI is *NOT* affected by this (even if you chose to use Log4J 1 as you default ESAPI logger). This security bulletin describes why this CVE is not exploitable as used by ESAPI.
 
 
 Finally, while ESAPI still supports JDK 7 (even though that too is way past end-of-life), the next ESAPI release will move to JDK 8 as the minimal baseline. (We already use Java 8 for development but still to Java 7 source and runtime compatibility.) We need to do this out of necessity because some of our dependencies are no longer doing updates that support Java 7.
@@ -126,11 +121,6 @@ Another problem is if you run 'mvn test' from the 'cmd' prompt (and possibly Pow
     C:\code\esapi-java-legacy> mvn test >testoutput.txt 2>&1
 
 We believe these failures is because the maven-surefire-plugin is by default not forking a new JVM process for each test class. We are looking into this. For now, we have only have observed this behavior on Windows 10. If you see this error, please do NOT report it as a GitHub issue unless you know a fix for it. (And yes, we are aware of '<reuseForks>false</reuseForks>' in the pom for the maven-surefire-plugin, but that causes other tests to fail that we haven't had time to fix.)
-
-
-Lastly, some SCA services may continue to flag vulnerabilties in ESAPI ${VERSION} related to log4j 1.2.17 (e.g., CVE-2020-9488). We do not believe the way that ESAPI uses log4j in a manner that leads to any exploitable behavior.  See the security bulletins
-   https://github.com/ESAPI/esapi-java-legacy/blob/develop/documentation/ESAPI-security-bulletin2.pdf 
-for additional details.
 
 -----------------------------------------------------------------------------
 

--- a/src/examples/java/DisplayEncryptedProperties.java
+++ b/src/examples/java/DisplayEncryptedProperties.java
@@ -8,7 +8,7 @@ import org.owasp.esapi.reference.crypto.DefaultEncryptedProperties;
 //          that were encrypted using ESAPI's EncryptedProperties class.
 //
 // Usage: java -classpath <cp> DisplayEncryptedProperties encryptedPropFileName
-//        where <cp> is proper classpath, which minimally include esapi.jar & log4j.jar
+//        where <cp> is proper classpath, which minimally includes the esapi.jar.
 public class DisplayEncryptedProperties {
 
     public DisplayEncryptedProperties() {

--- a/src/examples/java/ESAPILogging.java
+++ b/src/examples/java/ESAPILogging.java
@@ -4,7 +4,7 @@ import org.owasp.esapi.Logger;
 // Purpose: Short code snippet to show how ESAPI logging works.
 //
 // Usage: java -classpath <cp> ESAPILogging
-//        where <cp> is proper classpath, which minimally include esapi.jar & log4j.jar
+//        where <cp> is proper classpath, which minimally includes the esapi.jar.
 public class ESAPILogging {
 
     public static void main(String[] args) {

--- a/src/examples/scripts/encryptProperties.sh
+++ b/src/examples/scripts/encryptProperties.sh
@@ -49,8 +49,7 @@ cd ../java
 if [[ "$action" == "-display" ]]
 then
     set -x
-    java -Dlog4j.configuration="file:$log4j_properties" \
-         -Dorg.owasp.esapi.resources="$esapi_resources_test" \
+    java -Dorg.owasp.esapi.resources="$esapi_resources_test" \
          -classpath "$esapi_classpath" \
          DisplayEncryptedProperties "$filename"
 else
@@ -65,8 +64,7 @@ else
     echo
     echo "Hit <Enter> to continue..."; read GO
     set -x
-    java -Dlog4j.configuration="file:$log4j_properties" \
-         -Dorg.owasp.esapi.resources="$esapi_resources_test" \
+    java -Dorg.owasp.esapi.resources="$esapi_resources_test" \
          -classpath "$esapi_classpath" \
       org.owasp.esapi.reference.crypto.DefaultEncryptedProperties "$filename" &&
       echo "Output of encrypted properties in file: $filename"

--- a/src/examples/scripts/persistEncryptedData.sh
+++ b/src/examples/scripts/persistEncryptedData.sh
@@ -23,7 +23,6 @@ set -x
 # Since this is just an illustration, we will use the test ESAPI.properties in
 # $esapi_resources_test. That way, it won't matter if the user has neglected
 # to run the 'setMasterKey.sh' example before running this one.
-java -Dlog4j.configuration="file:$log4j_properties" \
-    -Dorg.owasp.esapi.resources="$esapi_resources_test" \
-    -ea -classpath "$esapi_classpath" \
-    PersistedEncryptedData "$@"
+java -Dorg.owasp.esapi.resources="$esapi_resources_test" \
+     -ea -classpath "$esapi_classpath" \
+     PersistedEncryptedData "$@"

--- a/src/examples/scripts/runClass.sh
+++ b/src/examples/scripts/runClass.sh
@@ -19,10 +19,8 @@ then echo >2&1 "Can't find class file: ${className}.class"
      exit 1
 fi
 echo "Your ESAPI.properties file: ${esapi_resources_test:?}/ESAPI.properties"
-echo "Your log4j properties file: ${log4j_properties:?}"
 echo
 set -x
-java -Dlog4j.configuration="file:$log4j_properties" \
-     -Dorg.owasp.esapi.resources="$esapi_resources_test" \
+java -Dorg.owasp.esapi.resources="$esapi_resources_test" \
      -classpath "$esapi_classpath" \
      ${className} "$@"

--- a/src/examples/scripts/setMasterKey.sh
+++ b/src/examples/scripts/setMasterKey.sh
@@ -16,7 +16,6 @@ echo
 # set -x
 # This should use the real ESAPI.properties in $esapi_resources that does
 # not yet have Encryptor.MasterKey and Encryptor.MasterSalt yet set.
-java -Dlog4j.configuration="file:$log4j_properties" \
-     -Dorg.owasp.esapi.resources="$esapi_resources" \
+java -Dorg.owasp.esapi.resources="$esapi_resources" \
      -classpath "$esapi_classpath" \
      org.owasp.esapi.reference.crypto.JavaEncryptor "$@"

--- a/src/examples/scripts/setenv-svn.sh
+++ b/src/examples/scripts/setenv-svn.sh
@@ -9,23 +9,17 @@
 #           where '$' represents the shell command line prompt.
 ###########################################################################
 
-# IMPORTANT NOTE:  Since you may have multiple (say) log4j jars under
-#                  your Maven2 repository under $HOME/.m2/respository, we
-#                  look for the specific versions that ESAPI was using as of
-#                  ESAPI 2.0_RC10 release on 2010/10/18. If these versions
-#                  changed, they will have to be reflected here.
-#
+# IMPORTANT NOTE:  These dependency versions may need updated. Should match
+#                  what is in ESAPI's pom.xml.
 esapi_classpath=".:\
 ../../../target/classes:\
 $(ls ../../../target/esapi-*.jar 2>&- || echo .):\
-$(./findjar.sh log4j-1.2.17.jar):\
-$(./findjar.sh commons-fileupload-1.3.1.jar):\
-$(./findjar.sh servlet-api-2.5.jar)"
+$(./findjar.sh commons-fileupload-1.4.jar):\
+$(./findjar.sh servlet-api-3.1.0.jar)"
 
 esapi_resources="$(\cd ../../../configuration/esapi >&- 2>&- && pwd)"
 esapi_resources_test="$(\cd ../../../src/test/resources/esapi >&- 2>&- && pwd)"
 
-log4j_properties="../../../src/test/resources/log4j.xml"
 
 if [[ ! -r "$esapi_resources"/ESAPI.properties ]]
 then echo 2>&1 "setenv-svn.sh: Can't read ESAPI.properties in $esapi_resources"
@@ -37,16 +31,10 @@ then echo 2>&1 "setenv-svn.sh: Can't read ESAPI.properties in $esapi_resources_t
      return 1   # Don't use 'exit' here or it will kill their current shell.
 fi
 
-if [[ ! -r "$log4j_properties" ]]
-then echo 2>&1 "setenv-svn.sh: Can't read log4j.xml: $log4j_properties"
-     return 1   # Don't use 'exit' here or it will kill their current shell.
-fi
-
 echo ############################################################
 echo "esapi_resources=$esapi_resources"
 echo "esapi_resources_test=$esapi_resources_test"
-echo "log4j_properties=$log4j_properties"
 echo "esapi_classpath=$esapi_classpath"
 echo ############################################################
 
-export esapi_classpath esapi_resources esapi_resources_test log4j_properties
+export esapi_classpath esapi_resources esapi_resources_test

--- a/src/examples/scripts/setenv-zip.sh
+++ b/src/examples/scripts/setenv-zip.sh
@@ -12,18 +12,15 @@
 # Here we don't look for the specific versions of the dependent libraries
 # since the specific version of the library is delivered as part of the
 # ESAPI zip file. In this manner, we do not have to update this if these
-# versions change. For the record, at the time of this writing, these were
-# log4j-1.2.17.jar, commons-fileupload-1.3.1.jar, and servlet-api-2.5.jar.
+# versions change.
 esapi_classpath=".:\
 $(ls ../../../esapi*.jar):\
-$(./findjar.sh -start ../../../libs log4j-*.jar):\
 $(./findjar.sh -start ../../../libs commons-fileupload-*.jar):\
 $(./findjar.sh -start ../../../libs servlet-api-*.jar)"
 
 esapi_resources="$(\cd ../../../configuration/esapi >&- 2>&- && pwd)"
 esapi_resources_test="$(\cd ../../../src/test/resources/esapi >&- 2>&- && pwd)"
 
-log4j_properties="../../../src/test/resources/log4j.xml"
 
 if [[ ! -r "$esapi_resources"/ESAPI.properties ]]
 then echo 2>&1 "setenv-svn.sh: Can't read ESAPI.properties in $esapi_resources"
@@ -35,16 +32,11 @@ then echo 2>&1 "setenv-svn.sh: Can't read ESAPI.properties in $esapi_resources_t
      return 1   # Don't use 'exit' here or it will kill their current shell.
 fi
 
-if [[ ! -r "$log4j_properties" ]]
-then echo 2>&1 "setenv-svn.sh: Can't read log4j.xml: $log4j_properties"
-     return 1   # Don't use 'exit' here or it will kill their current shell.
-fi
 
 echo ############################################################
 echo "esapi_resources=$esapi_resources"
 echo "esapi_resources_test=$esapi_resources_test"
-echo "log4j_properties=$log4j_properties"
 echo "esapi_classpath=$esapi_classpath"
 echo ############################################################
 
-export esapi_classpath esapi_resources esapi_resources_test log4j_properties
+export esapi_classpath esapi_resources esapi_resources_test

--- a/src/main/assembly/dist.xml
+++ b/src/main/assembly/dist.xml
@@ -38,8 +38,6 @@
             <outputDirectory>configuration</outputDirectory>
             <includes>
                 <include>esapi/**/*</include>
-                <include>log4j.dtd</include>
-                <include>log4j.xml</include>
                 <include>properties/**/*</include>
             </includes>
         </fileSet>

--- a/src/main/java/org/owasp/esapi/Logger.java
+++ b/src/main/java/org/owasp/esapi/Logger.java
@@ -16,12 +16,12 @@
 package org.owasp.esapi;
 
 /**
- * The Logger interface defines a set of methods that can be used to log
+ * The {@code Logger} interface defines a set of methods that can be used to log
  * security events. It supports a hierarchy of logging levels which can be configured at runtime to determine
  * the severity of events that are logged, and those below the current threshold that are discarded.
  * Implementors should use a well established logging library
  * as it is quite difficult to create a high-performance logger.
- * <P>
+ * <p>
  * The logging levels defined by this interface (in descending order) are:
  * <ul>
  * <li>fatal (highest value)</li>
@@ -33,9 +33,9 @@ package org.owasp.esapi;
  * </ul>
  * There are also several variations of {@code always()} methods that will <i>always</i>
  * log a message regardless of the log level.
- * <p>
+ * </p><p>
  * ESAPI also allows for the definition of the type of log event that is being generated.
- * The Logger interface predefines 6 types of Log events:
+ * The {@code Logger} interface predefines 6 types of Log events:
  * <ul>
  * <li>SECURITY_SUCCESS</li>
  * <li>SECURITY_FAILURE</li>
@@ -44,47 +44,54 @@ package org.owasp.esapi;
  * <li>EVENT_FAILURE</li>
  * <li>EVENT_UNSPECIFIED</li>
  * </ul>
- * <p>
- * Your implementation can extend or change this list if desired. 
- * <p>
- * This Logger allows callers to determine which logging levels are enabled, and to submit events 
+ * </p><p>
+ * Your custom implementation can extend or change this list if desired. 
+ * </p><p>
+ * This {@code Logger} allows callers to determine which logging levels are enabled, and to submit events 
  * at different severity levels.<br>
  * <br>Implementors of this interface should:
  * 
  * <ol>
- * <li>provide a mechanism for setting the logging level threshold that is currently enabled. This usually works by logging all 
+ * <li>Provide a mechanism for setting the logging level threshold that is currently enabled. This usually works by logging all 
  * events at and above that severity level, and discarding all events below that level.
  * This is usually done via configuration, but can also be made accessible programmatically.</li>
- * <li>ensure that dangerous HTML characters are encoded before they are logged to defend against malicious injection into logs 
+ * <li>Ensure that dangerous HTML characters are encoded before they are logged to defend against malicious injection into logs 
  * that might be viewed in an HTML based log viewer.</li>
- * <li>encode any CRLF characters included in log data in order to prevent log injection attacks.</li>
- * <li>avoid logging the user's session ID. Rather, they should log something equivalent like a 
+ * <li>Encode any CRLF characters included in log data in order to prevent log injection attacks.</li>
+ * <li>Avoid logging the user's session ID. Rather, they should log something equivalent like a 
  * generated logging session ID, or a hashed value of the session ID so they can track session specific 
  * events without risking the exposure of a live session's ID.</li> 
- * <li>record the following information with each event:</li>
+ * <li>Record the following information with each event:</li>
  *   <ol type="a">
- *   <li>identity of the user that caused the event,</li>
- *   <li>a description of the event (supplied by the caller),</li>
- *   <li>whether the event succeeded or failed (indicated by the caller),</li>
- *   <li>severity level of the event (indicated by the caller),</li>
- *   <li>that this is a security relevant event (indicated by the caller),</li>
- *   <li>hostname or IP where the event occurred (and ideally the user's source IP as well),</li>
- *   <li>a time stamp</li>
+ *   <li>Identity of the user that caused the event.</li>
+ *   <li>A description of the event (supplied by the caller).</li>
+ *   <li>Whether the event succeeded or failed (indicated by the caller).</li>
+ *   <li>Severity level of the event (indicated by the caller).</li>
+ *   <li>That this is a security relevant event (indicated by the caller).</li>
+ *   <li>Hostname or IP where the event occurred (and ideally the user's source IP as well).</li>
+ *   <li>A date/time stamp.</li>
  *   </ol>
  * </ol>
  *  
  * Custom logger implementations might also:
  * <ol start="6">
- * <li>filter out any sensitive data specific to the current application or organization, such as credit cards, 
+ * <li>Filter out any sensitive data specific to the current application or organization, such as credit cards, 
  * social security numbers, etc.</li>
  * </ol>
  * 
- * There are both Log4j and native Java Logging default implementations. JavaLogger uses the java.util.logging package as the basis for its logging 
- * implementation. Both default implementations implements requirements #1 thru #5 above.<br>
- * <br>
- * Customization: It is expected that most organizations will implement their own custom Logger class in 
- * order to integrate ESAPI logging with their logging infrastructure. The ESAPI Reference Implementation 
- * is intended to provide a simple functional example of an implementation.
+ * There are both SLF4J and native Java Logging (i.e., {@code java.util.logging}, aka JUL) implementations
+ * of the ESAPI logger with JUL being our default logger for our stock <b>ESAPI.properties</b> file that
+ * is delivered along with ESAPI releases in a separate <b>esapi-configuration</b> jar available from the
+ * releases mentioned on
+ * <a href="https://github.com/ESAPI/esapi-java-legacy/releases/">ESAPI's GitHub Releases page</a>.
+ * </p><p>
+ * The {@code org.owasp.esapi.logging.java.JavaLogger} class uses the {@code java.util.logging} package as
+ * the basis for its logging implementation. Both provided implementations implement requirements #1 through #5 above.
+ * </p><p>
+ * <i>Customization</i>: It is expected that most organizations may wish to implement their own custom {@code Logger} class in 
+ * order to integrate ESAPI logging with their specific logging infrastructure. The ESAPI feference implementations
+ * can serve as a useful starting point to intended to provide a simple functional example of an implementation, but
+ * they are also largely usuable out-of-the-box with some additional minimal log configuration.
  * 
  * @author Jeff Williams (jeff.williams .at. aspectsecurity.com) <a
  * href="http://www.aspectsecurity.com">Aspect Security</a>

--- a/src/main/java/org/owasp/esapi/waf/ESAPIWebApplicationFirewallFilter.java
+++ b/src/main/java/org/owasp/esapi/waf/ESAPIWebApplicationFirewallFilter.java
@@ -139,8 +139,18 @@ public class ESAPIWebApplicationFirewallFilter implements Filter {
 
 		logger.debug(Logger.EVENT_SUCCESS, ">> Initializing WAF");
 		/*
-		 * Pull logging file.
+		 * Pull logging file. -- We now ignore this arg, but will log something
+         * letting users know we are ignoring it, because many of them never
+         * seem to read the release notes. And this is probably better than
+         * throwing an exception.
 		 */
+        String logSettingsFilename = fc.getInitParameter(LOGGING_FILE_PARAM);
+        if ( logSettingsFilename != null ) {
+            logger.warning(Logger.EVENT_FAILURE, ">> Since ESAPI 2.5.0.0, ESAPI WAF ignoring parameter '" +
+                    LOGGING_FILE_PARAM + "; for further details, see " +
+                    "https://github.com/ESAPI/esapi-java-legacy/blob/develop/documentation/esapi4java-core-2.5.0.0-release-notes.txt");
+
+        }
 
 		/*
 		 * Pull main configuration file.

--- a/src/test/java/org/owasp/esapi/reference/TestDebug.java
+++ b/src/test/java/org/owasp/esapi/reference/TestDebug.java
@@ -8,7 +8,7 @@ import junit.framework.TestCase;
  * @author August Detlefsen (augustd at codemagi dot com)
  *         <a href="http://www.codemagi.com">CodeMagi, Inc.</a>
  * @since October 15, 2010
- * @see org.owasp.esapi.logging.log4j.Log4JLoggerTest
+ * @see org.owasp.esapi.logging.java.JavaLoggerTest
  */
 public class TestDebug extends TestCase {
 

--- a/src/test/java/org/owasp/esapi/reference/TestError.java
+++ b/src/test/java/org/owasp/esapi/reference/TestError.java
@@ -8,7 +8,7 @@ import junit.framework.TestCase;
  * @author August Detlefsen (augustd at codemagi dot com)
  *         <a href="http://www.codemagi.com">CodeMagi, Inc.</a>
  * @since October 15, 2010
- * @see org.owasp.esapi.logging.log4j.Log4JLoggerTest
+ * @see org.owasp.esapi.logging.java.JavaLoggerTest
  */
 public class TestError extends TestCase {
 

--- a/src/test/java/org/owasp/esapi/reference/TestFatal.java
+++ b/src/test/java/org/owasp/esapi/reference/TestFatal.java
@@ -8,7 +8,7 @@ import junit.framework.TestCase;
  * @author August Detlefsen (augustd at codemagi dot com)
  *         <a href="http://www.codemagi.com">CodeMagi, Inc.</a>
  * @since October 15, 2010
- * @see org.owasp.esapi.logging.log4j.Log4JLoggerTest
+ * @see org.owasp.esapi.logging.java.JavaLoggerTest
  */
 public class TestFatal extends TestCase {
 

--- a/src/test/java/org/owasp/esapi/reference/TestInfo.java
+++ b/src/test/java/org/owasp/esapi/reference/TestInfo.java
@@ -8,7 +8,7 @@ import junit.framework.TestCase;
  * @author August Detlefsen (augustd at codemagi dot com)
  *         <a href="http://www.codemagi.com">CodeMagi, Inc.</a>
  * @since October 15, 2010
- * @see org.owasp.esapi.logging.log4j.Log4JLoggerTest
+ * @see org.owasp.esapi.logging.java.JavaLoggerTest
  */
 public class TestInfo extends TestCase {
 

--- a/src/test/java/org/owasp/esapi/reference/TestTrace.java
+++ b/src/test/java/org/owasp/esapi/reference/TestTrace.java
@@ -8,7 +8,7 @@ import junit.framework.TestCase;
  * @author August Detlefsen (augustd at codemagi dot com)
  *         <a href="http://www.codemagi.com">CodeMagi, Inc.</a>
  * @since October 15, 2010
- * @see org.owasp.esapi.logging.log4j.Log4JLoggerTest
+ * @see org.owasp.esapi.logging.java.JavaLoggerTest
  */
 public class TestTrace extends TestCase {
 

--- a/src/test/java/org/owasp/esapi/reference/TestUnspecified.java
+++ b/src/test/java/org/owasp/esapi/reference/TestUnspecified.java
@@ -8,7 +8,7 @@ import junit.framework.TestCase;
  * @author August Detlefsen (augustd at codemagi dot com)
  *         <a href="http://www.codemagi.com">CodeMagi, Inc.</a>
  * @since October 15, 2010
- * @see org.owasp.esapi.logging.log4j.Log4JLoggerTest
+ * @see org.owasp.esapi.logging.java.JavaLoggerTest
  */
 public class TestUnspecified extends TestCase {
 

--- a/src/test/java/org/owasp/esapi/reference/TestWarning.java
+++ b/src/test/java/org/owasp/esapi/reference/TestWarning.java
@@ -8,7 +8,7 @@ import junit.framework.TestCase;
  * @author August Detlefsen (augustd at codemagi dot com)
  *         <a href="http://www.codemagi.com">CodeMagi, Inc.</a>
  * @since October 15, 2010
- * @see org.owasp.esapi.logging.log4j.Log4JLoggerTest
+ * @see org.owasp.esapi.logging.java.JavaLoggerTest
  */
 public class TestWarning extends TestCase {
 

--- a/src/test/java/org/owasp/esapi/waf/WAFTestUtility.java
+++ b/src/test/java/org/owasp/esapi/waf/WAFTestUtility.java
@@ -39,7 +39,19 @@ public class WAFTestUtility {
     public static void setWAFPolicy( ESAPIWebApplicationFirewallFilter waf, String policyFile ) throws Exception {
         Map map = new HashMap();
         map.put( "configuration", policyFile );
-        map.put( "log_settings", "../log4j.xml");
+
+            // As of ESAPI 2.5.0.0 (when Log4J 1 dependency was removed), thsi
+            // init parameter is not ignored. However, it will produce a warning
+            // log message that looks something like this:
+            //
+            // [2022-07-11 00:25:45] [org.owasp.esapi.waf.ESAPIWebApplicationFirewallFilter] [EVENT FAILURE Anonymous:90471@unknown -> 10.1.43.6:80/ExampleApplication/org.owasp.esapi.waf.ESAPIWebApplicationFirewallFilter] >> Since ESAPI 2.5.0.0, ESAPI WAF ignoring parameter 'log_settings; for further details, see https://github.com/ESAPI/esapi-java-legacy/blob/develop/documentation/esapi4java-core-2.5.0.0-release-notes.txt 
+            //
+            // Without getting really fancy and making this test way more
+            // complicated than I want though, I am not sure how to test for
+            // some specicif log output. It's been manually verified (once).
+            // Hopefully, that is good enough.      -kwwall
+            //
+        map.put( "log_settings", "parameter-now-ignored!!!");
         FilterConfig mfc = new MockWafFilterConfig( map );
         waf.init( mfc );
     }


### PR DESCRIPTION
In preparation for the ESAPI 2.5.0.0 release, which primarily addresses the removal of the Log4J 1 dependency for ESAPI logging (which has been deprecated for almost 2 years), this PR does the following:
1. Removes the final (non-documentation) vestiges of Log4J. Mostly was left in examples under 'src/examples', scripts under 'scripts' and in various comments. I did not remove it from documentation because of historical needs (e.g., people needing to look at old release notes or security bulletins).
2. Update pom.xml to use latest dependencies and Maven plugins. (Note: The official release of AntiSamy 1.7.0 is not yet in Maven Central, but we will upgrade to that once it is.)

Note that this PR does NOT include the release notes for 2.5.0.0.