### PR TITLE
Issue#735 ConfigurationException message changed to a more intuitive one

### DIFF
--- a/src/main/java/org/owasp/esapi/configuration/EsapiPropertyLoaderFactory.java
+++ b/src/main/java/org/owasp/esapi/configuration/EsapiPropertyLoaderFactory.java
@@ -52,7 +52,7 @@ public class EsapiPropertyLoaderFactory {
             return new StandardEsapiPropertyLoader(cfgPath, cfg.getPriority());
         } else {
             throw new ConfigurationException("The extension of given configuration path [ " + cfgPath + " ] is not supported." +
-                    "\nOnly .xml or .properties file extensions are supported.");
+                    "Only .xml or .properties file extensions are supported.");
         }
     }
 

--- a/src/main/java/org/owasp/esapi/configuration/EsapiPropertyLoaderFactory.java
+++ b/src/main/java/org/owasp/esapi/configuration/EsapiPropertyLoaderFactory.java
@@ -51,8 +51,8 @@ public class EsapiPropertyLoaderFactory {
         if (PROPERTIES.getTypeName().equalsIgnoreCase(fileExtension)) {
             return new StandardEsapiPropertyLoader(cfgPath, cfg.getPriority());
         } else {
-            throw new ConfigurationException("Configuration storage type [" + fileExtension + "] is not " +
-                    "supported");
+            throw new ConfigurationException("The extension of given configuration path [ " + cfgPath + " ] is not supported." +
+                    "\nOnly .xml or .properties file extensions are supported.");
         }
     }
 


### PR DESCRIPTION
It was asked to change the message given by an exception in the EsapiPropertyLoaderFactory Class that specified that only .xml files or .properties files were allowed. 
So, using a user-friendly approach, I decided to call the ending of the file an "extension" and told in the message that only files with the  .xml or .properties "file extension" were supported.