### PR TITLE
Issue 710 JUL Respect LogManager Config

### DIFF
--- a/src/main/java/org/owasp/esapi/logging/java/JavaLogFactory.java
+++ b/src/main/java/org/owasp/esapi/logging/java/JavaLogFactory.java
@@ -48,9 +48,9 @@ import static org.owasp.esapi.PropNames.LOG_SERVER_IP;
  * Options for customizing this configuration (in recommended order)
  * <ol>
  * <li>Consider using the <i>SLF4JLogFactory</i> with a java-logging implementation.</li>
- * <li>Configure java LogManager system properties as defined by the <i>java.util.logging.LogManager</i> API</li>
+ * <li>Configure the runtime startup command to set the desired system properties for the <i>java.util.logging.LogManager</i> instance.  EG: <code>-Djava.util.logging.config.file=/custom/file/path.properties</code></li>
  * <li>Overwrite the esapi-java-logging.properties file with the desired logging configurations. <br>A default file implementation is available in the configuration jar on GitHub under the 'Releases'</li>
- * <li>Specifically set the system property for LogManager in the custom-code solution to prevent ESAPI JavaLogFactory from overriding project configuration</li>
+ * <li>Apply custom-code solution to set the system properties for the <i>java.util.logging.LogManager</i> at runtime. EG: <code>System.setProperty("java.util.logging.config.file", "/custom/file/path.properties");</code></li>
  * <li>Create a custom JavaLogFactory class in client project baseline and update the ESAPI.properties configuration to use that reference.</li>
  * </ol>
  *

--- a/src/main/java/org/owasp/esapi/logging/java/JavaLogFactory.java
+++ b/src/main/java/org/owasp/esapi/logging/java/JavaLogFactory.java
@@ -47,7 +47,7 @@ import static org.owasp.esapi.PropNames.LOG_SERVER_IP;
  * Options for customizing this configuration (in recommended order)
  * <ol>
  * <li>Consider using the <i>SLF4JLogFactory</i> with a java-logging implementation.</li>
- * <li>Configure java LogManager environment properties as defined by the <i>java.util.logging.LogManager</i> API</li>
+ * <li>Configure java LogManager system properties as defined by the <i>java.util.logging.LogManager</i> API</li>
  * <li>Overwrite the esapi-java-logging.properties file with the desired logging configurations. <br>A default file implementation is available in the configuration jar on GitHub under the 'Releases'</li>
  * <li>Specifically set the system property for LogManager in the custom-code solution to prevent ESAPI JavaLogFactory from overriding project configuration</li>
  * <li>Create a custom JavaLogFactory class in client project baseline and update the ESAPI.properties configuration to use that reference.</li>

--- a/src/main/java/org/owasp/esapi/logging/java/JavaLogFactory.java
+++ b/src/main/java/org/owasp/esapi/logging/java/JavaLogFactory.java
@@ -25,6 +25,7 @@ import java.util.logging.LogManager;
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.LogFactory;
 import org.owasp.esapi.Logger;
+import org.owasp.esapi.PropNames;
 import org.owasp.esapi.codecs.HTMLEntityCodec;
 import org.owasp.esapi.errors.ConfigurationException;
 import org.owasp.esapi.logging.appender.LogAppender;
@@ -102,6 +103,18 @@ public class JavaLogFactory implements LogFactory {
         "java.util.logging.config.class".equals(propKey) || "java.util.logging.config.file".equals(propKey))) {
             // LogManager has external configuration.  Do not load ESAPI defaults.
             // See javadoc for the LogManager class for more information on properties.
+            boolean isStartupSysoutDisabled = Boolean.valueOf(System.getProperty(PropNames.DISCARD_LOGSPECIAL, Boolean.FALSE.toString()));
+            if (!isStartupSysoutDisabled) {
+                String logManagerPreferredMsg = String.format("[ESAPI-STARTUP] ESAPI JavaLogFactory Configuration will not be applied. "
+                        + "java.util.LogManager configuration Detected. "
+                        + "{\"java.util.logging.config.class\":\"%s\",\"java.util.logging.config.file\":\"%s\"}",
+                        System.getProperty("java.util.logging.config.class"), System.getProperty("java.util.logging.config.file"));
+
+                System.out.println(logManagerPreferredMsg);
+                // ::SAMPLE OUTPUT::
+                //[ESAPI-STARTUP] ESAPI JavaLogFactory Configuration will not be applied.  java.util.LogManager configuration Detected.{"java.util.logging.config.class":"some.defined.value","java.util.logging.config.file":"null"}
+            }
+
             return;
         }
         /*

--- a/src/main/java/org/owasp/esapi/logging/java/JavaLogFactory.java
+++ b/src/main/java/org/owasp/esapi/logging/java/JavaLogFactory.java
@@ -43,10 +43,15 @@ import static org.owasp.esapi.PropNames.LOG_SERVER_IP;
 
 /**
  * LogFactory implementation which creates JAVA supporting Loggers.
- *
- * This implementation requires that a file named 'esapi-java-logging.properties' exists on the classpath.
- * <br>
- * A default file implementation is available in the configuration jar on GitHub under the 'Releases'
+ * <br><br>
+ * Options for customizing this configuration (in recommended order)
+ * <ol>
+ * <li>Consider using the <i>SLF4JLogFactory</i> with a java-logging implementation.</li>
+ * <li>Configure java LogManager environment properties as defined by the <i>java.util.logging.LogManager</i> API</li>
+ * <li>Overwrite the esapi-java-logging.properties file with the desired logging configurations. <br>A default file implementation is available in the configuration jar on GitHub under the 'Releases'</li>
+ * <li>Specifically set the system property for LogManager in the custom-code solution to prevent ESAPI JavaLogFactory from overriding project configuration</li>
+ * <li>Create a custom JavaLogFactory class in client project baseline and update the ESAPI.properties configuration to use that reference.</li>
+ * </ol>
  *
  */
 public class JavaLogFactory implements LogFactory {

--- a/src/main/java/org/owasp/esapi/logging/java/JavaLogFactory.java
+++ b/src/main/java/org/owasp/esapi/logging/java/JavaLogFactory.java
@@ -53,6 +53,8 @@ import static org.owasp.esapi.PropNames.LOG_SERVER_IP;
  * <li>Apply custom-code solution to set the system properties for the <i>java.util.logging.LogManager</i> at runtime. EG: <code>System.setProperty("java.util.logging.config.file", "/custom/file/path.properties");</code></li>
  * <li>Create a custom JavaLogFactory class in client project baseline and update the ESAPI.properties configuration to use that reference.</li>
  * </ol>
+ * 
+ * @see <a href="https://github.com/ESAPI/esapi-java-legacy/wiki/Configuration-Reference:-JavaLogFactory">ESAPI Wiki - Configuration Reference: JavaLogFactory</a>
  *
  */
 public class JavaLogFactory implements LogFactory {

--- a/src/main/java/org/owasp/esapi/logging/java/JavaLogFactory.java
+++ b/src/main/java/org/owasp/esapi/logging/java/JavaLogFactory.java
@@ -93,6 +93,12 @@ public class JavaLogFactory implements LogFactory {
      * @param logManager LogManager which is being configured.
      */
     /*package*/ static void readLoggerConfiguration(LogManager logManager) {
+        if (System.getProperties().keySet().stream().anyMatch(propKey ->
+        "java.util.logging.config.class".equals(propKey) || "java.util.logging.config.file".equals(propKey))) {
+            // LogManager has external configuration.  Do not load ESAPI defaults.
+            // See javadoc for the LogManager class for more information on properties.
+            return;
+        }
         /*
          * This will load the logging properties file to control the format of the output for Java logs.
          */

--- a/src/test/java/org/owasp/esapi/logging/java/JavaLogFactoryTest.java
+++ b/src/test/java/org/owasp/esapi/logging/java/JavaLogFactoryTest.java
@@ -49,6 +49,59 @@ public class JavaLogFactoryTest {
     public ExpectedException exEx = ExpectedException.none();
 
     @Test
+    public void testLogManagerConfigurationAsClass() throws Exception {
+        String propKey = "java.util.logging.config.class";
+        //If defined, grab the value; otherwise, set to a known value to allow for prop to be cleared.
+        String sysDefault = System.getProperties().stringPropertyNames().contains(propKey) ? System.getProperty(propKey) : testName.getMethodName();
+
+        System.setProperty(propKey, "some.defined.value");
+        LogManager testLogManager = new LogManager() {
+            @Override
+            public void readConfiguration(InputStream ins) throws IOException, SecurityException {
+                throw new IOException(testName.getMethodName());
+            }
+        };
+
+        try {
+            // This would throw an IOException if the LogManager was not being respected since no esapi-java-logging file is specified
+            JavaLogFactory.readLoggerConfiguration(testLogManager);
+        } finally {
+            //Restore original prop values
+            if (testName.getMethodName().equals(sysDefault))
+                System.clearProperty(propKey);
+            else {
+                System.setProperty(propKey, sysDefault);
+            }
+        }
+    }
+
+    @Test
+    public void testLogManagerConfigurationAsFile() throws Exception {
+        String propKey = "java.util.logging.config.file";
+        //If defined, grab the value; otherwise, set to a known value to allow for prop to be cleared.
+        String sysDefault = System.getProperties().stringPropertyNames().contains(propKey) ? System.getProperty(propKey) : testName.getMethodName();
+
+        System.setProperty(propKey, "some.defined.value");
+        LogManager testLogManager = new LogManager() {
+            @Override
+            public void readConfiguration(InputStream ins) throws IOException, SecurityException {
+                throw new IOException(testName.getMethodName());
+            }
+        };
+
+        try {
+            // This would throw an IOException if the LogManager was not being respected since no esapi-java-logging file is specified
+            JavaLogFactory.readLoggerConfiguration(testLogManager);
+        } finally {
+            //Restore original prop values
+            if (testName.getMethodName().equals(sysDefault)) {
+                System.clearProperty(propKey);
+            } else {
+                System.setProperty(propKey, sysDefault);
+            } 
+        }
+    }
+    @Test
     public void testConfigurationExceptionOnMissingConfiguration() throws Exception {
         final IOException originException = new IOException(testName.getMethodName());
 
@@ -65,7 +118,7 @@ public class JavaLogFactoryTest {
         exEx.expectCause(new CustomMatcher<Throwable>("Check for IOException") {
             @Override
             public boolean matches(Object item) {
-               return item instanceof IOException;
+                return item instanceof IOException;
             }
         });
 


### PR DESCRIPTION
Closes #710 

Updating JUL to check for existing global LogManager configuration prior to applying ESAPI file settings.

Adding tests to verify LogManager Configurations are preferred to the ESAPI configurations.