### PR TITLE
Fix fluido skin plugin version inheritance from pom to src/site/site.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /target
 /.settings/**
 .classpath
+.java-version
 .project
 *.swp
 *~

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <version.powermock>2.0.9</version.powermock>
         <version.spotbugs>4.7.3</version.spotbugs>
         <version.spotbugs.maven>4.7.3.0</version.spotbugs.maven>
-        <version.surefire>3.0.0-M8</version.surefire>
+        <version.surefire>3.0.0-M9</version.surefire>
         <project.java.target>1.8</project.java.target>
             <!-- TODO: Be sure to update. Should be date of previous official release -->
             <!-- Exact date in the form 'yyyy-dd-yy 00:00:00' should be used. You can find the previous release date -->
@@ -227,7 +227,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.4</version>
+            <version>1.5</version>
             <exclusions>
                 <!-- excluded because we directly import newer version. -->
                 <exclusion>
@@ -306,8 +306,14 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.70</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
+            <artifactId>hamcrest-core</artifactId>
             <version>2.2</version>
             <scope>test</scope>
         </dependency>
@@ -401,7 +407,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.4.2</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -416,7 +422,7 @@
                 <plugin>
                      <groupId>org.codehaus.mojo</groupId>
                      <artifactId>versions-maven-plugin</artifactId>
-                     <version>2.14.2</version>
+                     <version>2.15.0</version>
                      <configuration>
                          <rulesUri>file:${project.basedir}/versionRuleset.xml</rulesUri>
                      </configuration>
@@ -429,7 +435,7 @@
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
-                <version>2.7.4</version>
+                <version>2.7.5</version>
                 <executions>
                   <execution>
                     <phase>package</phase>
@@ -511,7 +517,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
             </plugin>
 
             <plugin>
@@ -526,7 +532,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.1</version>
                 <dependencies>
                   <dependency>
                     <groupId>org.codehaus.mojo</groupId>
@@ -635,7 +641,7 @@
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-javadoc-plugin</artifactId>
-               <version>3.4.1</version>
+               <version>3.5.0</version>
                <configuration>
                  <source>8</source>
                  <doclint>none</doclint>
@@ -739,7 +745,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>8.0.1</version>
+                <version>8.1.0</version>
                 <configuration>
                     <failBuildOnCVSS>1.0</failBuildOnCVSS>
                     <suppressionFiles>./suppressions.xml</suppressionFiles>

--- a/pom.xml
+++ b/pom.xml
@@ -137,15 +137,16 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	    <version.jmh>1.36</version.jmh>
+        <version.findsecbugs>1.12.0</version.findsecbugs>
+        <version.fluido>1.11.1</version.fluido>
         <version.powermock>2.0.9</version.powermock>
         <version.spotbugs>4.7.3</version.spotbugs>
-        <version.findsecbugs>1.12.0</version.findsecbugs>
         <version.spotbugs.maven>4.7.3.0</version.spotbugs.maven>
-        <version.surefire>3.0.0-M7</version.surefire>
+        <version.surefire>3.0.0-M8</version.surefire>
         <project.java.target>1.8</project.java.target>
             <!-- TODO: Be sure to update. Should be date of previous official release -->
             <!-- Exact date in the form 'yyyy-dd-yy 00:00:00' should be used. You can find the previous release date -->
-            <!-- n the previous release notes file under the 'documentation/' directory. -->
+            <!-- in the previous release notes file under the 'documentation/' directory. -->
         <date.prev_release>2022-07-20 00:00:00</date.prev_release>
     </properties>
 
@@ -305,14 +306,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.70</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
+            <artifactId>hamcrest</artifactId>
             <version>2.2</version>
             <scope>test</scope>
         </dependency>
@@ -411,7 +406,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -421,7 +416,7 @@
                 <plugin>
                      <groupId>org.codehaus.mojo</groupId>
                      <artifactId>versions-maven-plugin</artifactId>
-                     <version>2.13.0</version>
+                     <version>2.14.2</version>
                      <configuration>
                          <rulesUri>file:${project.basedir}/versionRuleset.xml</rulesUri>
                      </configuration>
@@ -434,7 +429,7 @@
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
-                <version>2.7.3</version>
+                <version>2.7.4</version>
                 <executions>
                   <execution>
                     <phase>package</phase>
@@ -536,12 +531,12 @@
                   <dependency>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>extra-enforcer-rules</artifactId>
-                    <version>1.6.0</version>
+                    <version>1.6.1</version>
                   </dependency>
                   <dependency>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>animal-sniffer-enforcer-rule</artifactId>
-                    <version>1.21</version>
+                    <version>1.22</version>
                   </dependency>
 
                 </dependencies>
@@ -664,13 +659,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.19.0</version>
+                <version>3.20.0</version>
             </plugin>
 
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-project-info-reports-plugin</artifactId>
-               <version>3.4.1</version>
+               <version>3.4.2</version>
             </plugin>
 
             <plugin>
@@ -684,12 +679,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>4.0.0-M3</version>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.skins</groupId>
-                <artifactId>maven-fluid-skin</artifactId>
-                <version>1.11.1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.skins</groupId>
+                        <artifactId>maven-fluido-skin</artifactId>
+                        <version>${version.fluido}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
 
             <plugin>
@@ -743,7 +739,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>7.3.2</version>
+                <version>8.0.1</version>
                 <configuration>
                     <failBuildOnCVSS>1.0</failBuildOnCVSS>
                     <suppressionFiles>./suppressions.xml</suppressionFiles>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -9,6 +9,7 @@
     <skin>
         <groupId>org.apache.maven.skins</groupId>
         <artifactId>maven-fluido-skin</artifactId>
+        <version>${version.fluido}</version>
     </skin>
     <custom>
         <fluidoSkin>


### PR DESCRIPTION
Fix fluido skin version inheritance from pom to src/site/site.xml file. And upgrade a number of plugins and maybe one library. Fix some used undeclared and unused declared imports.