### PR TITLE
remove dependency on servlet API (use case where not needed)

### DIFF
--- a/src/main/java/org/owasp/esapi/logging/appender/ServerInfoSupplier.java
+++ b/src/main/java/org/owasp/esapi/logging/appender/ServerInfoSupplier.java
@@ -51,9 +51,11 @@ public class ServerInfoSupplier     // implements Supplier<String>
     public String get() {
         // log server, port, app name, module name -- server:80/app/module
         StringBuilder appInfo = new StringBuilder();
-        HttpServletRequest request = ESAPI.currentRequest();
-        if (request != null && logServerIP) {
-            appInfo.append(request.getLocalAddr()).append(":").append(request.getLocalPort());
+        if (logServerIP) {
+            HttpServletRequest request = ESAPI.currentRequest();
+            if (request != null) {
+                appInfo.append(request.getLocalAddr()).append(":").append(request.getLocalPort());
+            }
         }
         if (logAppName) {
             appInfo.append("/").append(applicationName);

--- a/src/test/java/org/owasp/esapi/logging/appender/ServerInfoSupplierTest.java
+++ b/src/test/java/org/owasp/esapi/logging/appender/ServerInfoSupplierTest.java
@@ -72,7 +72,7 @@ public class ServerInfoSupplierTest {
 
     @Test
     public void verifyOutputNullAppName() throws Exception {
-        when(ESAPI.class, "currentRequest").thenReturn(null);
+        when(ESAPI.class, "currentRequest").thenReturn(request);
         when(request.getLocalAddr()).thenReturn("LOCAL_ADDR");
         when(request.getLocalPort()).thenReturn(99999);
 

--- a/src/test/java/org/owasp/esapi/logging/appender/ServerInfoSupplierTest.java
+++ b/src/test/java/org/owasp/esapi/logging/appender/ServerInfoSupplierTest.java
@@ -25,14 +25,14 @@ public class ServerInfoSupplierTest {
     private HttpServletRequest request;
 
     @Before
-    public void buildStaticMocks() throws Exception {
+    public void buildStaticMocks() {
         request = mock(HttpServletRequest.class);
         mockStatic(ESAPI.class);
-        when(ESAPI.class, "currentRequest").thenReturn(request);
     }
 
     @Test
-    public void verifyFullOutput() {
+    public void verifyFullOutput() throws Exception {
+        when(ESAPI.class, "currentRequest").thenReturn(request);
         when(request.getLocalAddr()).thenReturn("LOCAL_ADDR");
         when(request.getLocalPort()).thenReturn(99999);
 
@@ -57,7 +57,8 @@ public class ServerInfoSupplierTest {
     }
 
     @Test
-    public void verifyOutputNoAppName() {
+    public void verifyOutputNoAppName() throws Exception {
+        when(ESAPI.class, "currentRequest").thenReturn(request);
         when(request.getLocalAddr()).thenReturn("LOCAL_ADDR");
         when(request.getLocalPort()).thenReturn(99999);
 
@@ -70,7 +71,8 @@ public class ServerInfoSupplierTest {
     }
 
     @Test
-    public void verifyOutputNullAppName() {
+    public void verifyOutputNullAppName() throws Exception {
+        when(ESAPI.class, "currentRequest").thenReturn(null);
         when(request.getLocalAddr()).thenReturn("LOCAL_ADDR");
         when(request.getLocalPort()).thenReturn(99999);
 


### PR DESCRIPTION
**I have recreated PR #772, except this time I have properly signed the commit.**

This change deals with issue #767.

It does not attempt to resolve the overall issue with Servlet API version compatibility. What it does is remove the dependency on Servlet API for the use case where a user is trying to use the logger functionality, but has "logServerIP" set to false. When not logging the server IP, there is no reason for this code to depend on Servlet API at all.

This allows us to avoid runtime exceptions if we use this code with the new Jakarta package version of Servlet API, in cases where logServerIP is disabled.

Again, this is not a fix for the overall problem. This is a small change that will let some limited use cases not fail due to the problem (so that those use cases can get by until this problem is solved in a more holistic way).

The change stems from part of this discussion:
https://github.com/ESAPI/esapi-java-legacy/discussions/768#discussioncomment-4672270