### PR TITLE
fix: upgrade Antisamy to 1.7.5 to resolve CVE-2024-23635

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,12 +243,17 @@
         <dependency>
             <groupId>org.owasp.antisamy</groupId>
             <artifactId>antisamy</artifactId>
-            <version>1.7.4</version>
+            <version>1.7.5</version>
             <exclusions>
                 <!-- excluded because we directly import newer version below. -->
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <!-- excluded because commons-beanutils imports a newer version. -->
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -281,7 +286,7 @@
             -->
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.14.0</version>
+            <version>2.15.1</version>
         </dependency>
 
         <!-- SpotBugs dependencies -->

--- a/src/test/java/org/owasp/esapi/reference/validation/HTMLValidationRuleCleanTest.java
+++ b/src/test/java/org/owasp/esapi/reference/validation/HTMLValidationRuleCleanTest.java
@@ -362,6 +362,10 @@ public class HTMLValidationRuleCleanTest {
     //
     // See AntiSamy GitHub issue #380 (https://github.com/nahsra/antisamy/issues/389) for more details.
     //
+    // The output has changed again as of AntiSamy 1.7.5. The expected output is now:
+    //      Walert(1)
+    // See AntiSamy Release notes for 1.7.5 (https://github.com/nahsra/antisamy/releases/tag/v1.7.5)
+    //
     // Also, this test, which originally used Validator.isValidSafeHTML(), has been
     // changed to use Validator.getValidSafeHTML() instead because Validator.isValidSafeHTML()
     // has been deprecated. See GitHub Security Advisory
@@ -375,7 +379,8 @@ public class HTMLValidationRuleCleanTest {
         ValidationErrorList errors = new ValidationErrorList();
         String input = "<select<style/>W<xmp<script>alert(1)</script>";
         // String expected = "W&lt;script&gt;alert(1)&lt;/script&gt;";        // Before AntiSamy 1.7.4
-        String expected = "W&lt;xmp&lt;script&gt;alert(1)&lt;/script&gt;";    // AntiSamy 1.7.4 (and later?)
+        // String expected = "W&lt;xmp&lt;script&gt;alert(1)&lt;/script&gt;";    // AntiSamy 1.7.4
+        String expected = "Walert(1)";                                      // AntiSamy 1.7.5 (and later?)
         String output = instance.getValidSafeHTML("escaping style tag attack with script tag", input, 250, false, errors);
         assertEquals(expected, output);
         assertTrue(errors.size() == 0);
@@ -392,6 +397,10 @@ public class HTMLValidationRuleCleanTest {
     //
     // See AntiSamy GitHub issue #380 (https://github.com/nahsra/antisamy/issues/389) for more details.
     //
+    // The output has changed again as of AntiSamy 1.7.5. The expected output is now:
+    //      kinput/onfocus=alert(1)&gt;
+    // See AntiSamy Release notes for 1.7.5 (https://github.com/nahsra/antisamy/releases/tag/v1.7.5)
+    //
     // Also, this test, which originally used Validator.isValidSafeHTML(), has been
     // changed to use Validator.getValidSafeHTML() instead because Validator.isValidSafeHTML()
     // has been deprecated. See GitHub Security Advisory
@@ -405,7 +414,8 @@ public class HTMLValidationRuleCleanTest {
         String input = "<select<style/>k<input<</>input/onfocus=alert(1)>";
 
         // String expected = "k&lt;input/onfocus=alert(1)&gt;";    // Before AntiSamy 1.7.4
-        String expected = "k&lt;input&lt;&lt;/&gt;input/onfocus=alert(1)&gt;";    // AntiSamy 1.7.4 (and later?)
+        // String expected = "k&lt;input&lt;&lt;/&gt;input/onfocus=alert(1)&gt;";    // AntiSamy 1.7.4
+        String expected = "kinput/onfocus=alert(1)&gt;";    // AntiSamy 1.7.5 (and later?)
         String output = instance.getValidSafeHTML("escaping style tag attack with onfocus attribute", input, 250, false, errors);
         assertEquals(expected, output);
         assertTrue(errors.size() == 0);


### PR DESCRIPTION
This is to resolve CVE-2024-23635 relating to Antisamy 1.7.4.
It's related and similar to https://github.com/ESAPI/esapi-java-legacy/pull/830, however it resolves dependency conflicts and updates 2 test cases as the output we get from Antisamy looks a bit different. I think this is to be expected: as mentioned in the [release notes](https://github.com/nahsra/antisamy/releases/tag/v1.7.5) for Antisamy 1.7.5 the output may have changed again:
> Note: The upgrade in the HTML parser may alter outputs compared to 1.7.4 and before. This may impact regression tests that involve AntiSamy if they are too strict when comparing a resulting output with the expected one.

Also related to: https://github.com/nahsra/antisamy/issues/389 and https://github.com/nahsra/antisamy/pull/388.