### PR TITLE
Issue #839 JavaLogFactory ConcMod

### DIFF
--- a/configuration/esapi/esapi-java-logging.properties
+++ b/configuration/esapi/esapi-java-logging.properties
@@ -1,6 +1,0 @@
-handlers= java.util.logging.ConsoleHandler
-.level= INFO
-java.util.logging.ConsoleHandler.level = INFO
-java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
-java.util.logging.SimpleFormatter.format=[%1$tF %1$tT] [%3$-7s] %5$s %n
-#https://www.logicbig.com/tutorials/core-java-tutorial/logging/customizing-default-format.html

--- a/src/main/java/org/owasp/esapi/logging/java/JavaLogFactory.java
+++ b/src/main/java/org/owasp/esapi/logging/java/JavaLogFactory.java
@@ -14,8 +14,16 @@
  */
 package org.owasp.esapi.logging.java;
 
+import static org.owasp.esapi.PropNames.APPLICATION_NAME;
+import static org.owasp.esapi.PropNames.LOG_APPLICATION_NAME;
+import static org.owasp.esapi.PropNames.LOG_CLIENT_INFO;
+import static org.owasp.esapi.PropNames.LOG_ENCODING_REQUIRED;
+import static org.owasp.esapi.PropNames.LOG_SERVER_IP;
+import static org.owasp.esapi.PropNames.LOG_USER_INFO;
+
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -25,7 +33,6 @@ import java.util.logging.LogManager;
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.LogFactory;
 import org.owasp.esapi.Logger;
-import org.owasp.esapi.PropNames;
 import org.owasp.esapi.codecs.HTMLEntityCodec;
 import org.owasp.esapi.errors.ConfigurationException;
 import org.owasp.esapi.logging.appender.LogAppender;
@@ -34,13 +41,6 @@ import org.owasp.esapi.logging.cleaning.CodecLogScrubber;
 import org.owasp.esapi.logging.cleaning.CompositeLogScrubber;
 import org.owasp.esapi.logging.cleaning.LogScrubber;
 import org.owasp.esapi.logging.cleaning.NewlineLogScrubber;
-
-import static org.owasp.esapi.PropNames.LOG_ENCODING_REQUIRED;
-import static org.owasp.esapi.PropNames.LOG_USER_INFO;
-import static org.owasp.esapi.PropNames.LOG_CLIENT_INFO;
-import static org.owasp.esapi.PropNames.LOG_APPLICATION_NAME;
-import static org.owasp.esapi.PropNames.APPLICATION_NAME;
-import static org.owasp.esapi.PropNames.LOG_SERVER_IP;
 
 /**
  * LogFactory implementation which creates JAVA supporting Loggers.
@@ -93,43 +93,24 @@ public class JavaLogFactory implements LogFactory {
 
         LOG_BRIDGE = new JavaLogBridgeImpl(JAVA_LOG_APPENDER, JAVA_LOG_SCRUBBER, levelLookup);
 
-        readLoggerConfiguration(LogManager.getLogManager());
-    }
-
-    /**
-     * Attempts to load the expected property file path into the provided LogManager reference.
-     * @param logManager LogManager which is being configured.
-     */
-    /*package*/ static void readLoggerConfiguration(LogManager logManager) {
-        if (System.getProperties().keySet().stream().anyMatch(propKey ->
-        "java.util.logging.config.class".equals(propKey) || "java.util.logging.config.file".equals(propKey))) {
-            // LogManager has external configuration.  Do not load ESAPI defaults.
-            // See javadoc for the LogManager class for more information on properties.
-            boolean isStartupSysoutDisabled = Boolean.valueOf(System.getProperty(PropNames.DISCARD_LOGSPECIAL, Boolean.FALSE.toString()));
-            if (!isStartupSysoutDisabled) {
-                String logManagerPreferredMsg = String.format("[ESAPI-STARTUP] ESAPI JavaLogFactory Configuration will not be applied. "
-                        + "java.util.LogManager configuration Detected. "
-                        + "{\"java.util.logging.config.class\":\"%s\",\"java.util.logging.config.file\":\"%s\"}",
-                        System.getProperty("java.util.logging.config.class"), System.getProperty("java.util.logging.config.file"));
-
-                System.out.println(logManagerPreferredMsg);
-                // ::SAMPLE OUTPUT::
-                //[ESAPI-STARTUP] ESAPI JavaLogFactory Configuration will not be applied.  java.util.LogManager configuration Detected.{"java.util.logging.config.class":"some.defined.value","java.util.logging.config.file":"null"}
-            }
-
-            return;
-        }
         /*
-         * This will load the logging properties file to control the format of the output for Java logs.
+         * esapi-java-logging.properties file may lead to confusing logging behavior
+         * by overriding desired configurations provided through Java's LogManager class.
+         * 
+         * Verify the file is not present and fail if found to enforce understanding of
+         * the configuration method.
          */
         try (InputStream stream = JavaLogFactory.class.getClassLoader().
                 getResourceAsStream("esapi-java-logging.properties")) {
-            if (stream == null) {
-                throw new ConfigurationException("Unable to locate resource: esapi-java-logging.properties");
+            if (stream != null) {
+                throw new ConfigurationException("esapi-java-logging.properties is no longer supported.  See https://github.com/ESAPI/esapi-java-legacy/wiki/Configuring-the-JavaLogFactory for information on corrective actions.");
             }
-            logManager.readConfiguration(stream);
+
         } catch (IOException ioe) {
-            throw new ConfigurationException("Failed to load esapi-java-logging.properties.", ioe);
+            // This is a little strange, I know.
+            // If the IOException is thrown, then the file actually exists but is malformatted or has some other issue.
+            // The file should not exist at all, so use the same message as above but include the original exception in the log as well.
+            throw new ConfigurationException("esapi-java-logging.properties is no longer supported.  See https://github.com/ESAPI/esapi-java-legacy/wiki/Configuring-the-JavaLogFactory for information on corrective actions.", ioe);
         }
     }
 

--- a/src/main/java/org/owasp/esapi/logging/java/JavaLogFactory.java
+++ b/src/main/java/org/owasp/esapi/logging/java/JavaLogFactory.java
@@ -23,12 +23,10 @@ import static org.owasp.esapi.PropNames.LOG_USER_INFO;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.LogManager;
 
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.LogFactory;
@@ -58,6 +56,8 @@ import org.owasp.esapi.logging.cleaning.NewlineLogScrubber;
  *
  */
 public class JavaLogFactory implements LogFactory {
+    /**Consistent message offered as a part of the ConfigurationException which is thrown if esapi-java-logging.properties is found on the path. */
+    private static final String PROPERTY_CONFIG_MSG = "esapi-java-logging.properties is no longer supported.  See https://github.com/ESAPI/esapi-java-legacy/wiki/Configuring-the-JavaLogFactory for information on corrective actions.";
     /** Immune characters for the codec log scrubber for JAVA context.*/
     private static final char[] IMMUNE_JAVA_HTML = {',', '.', '-', '_', ' ' };
     /** Codec being used to clean messages for logging.*/
@@ -103,14 +103,14 @@ public class JavaLogFactory implements LogFactory {
         try (InputStream stream = JavaLogFactory.class.getClassLoader().
                 getResourceAsStream("esapi-java-logging.properties")) {
             if (stream != null) {
-                throw new ConfigurationException("esapi-java-logging.properties is no longer supported.  See https://github.com/ESAPI/esapi-java-legacy/wiki/Configuring-the-JavaLogFactory for information on corrective actions.");
+                throw new ConfigurationException(PROPERTY_CONFIG_MSG);
             }
 
         } catch (IOException ioe) {
             // This is a little strange, I know.
             // If the IOException is thrown, then the file actually exists but is malformatted or has some other issue.
             // The file should not exist at all, so use the same message as above but include the original exception in the log as well.
-            throw new ConfigurationException("esapi-java-logging.properties is no longer supported.  See https://github.com/ESAPI/esapi-java-legacy/wiki/Configuring-the-JavaLogFactory for information on corrective actions.", ioe);
+            throw new ConfigurationException(PROPERTY_CONFIG_MSG, ioe);
         }
     }
 

--- a/src/test/java/org/owasp/esapi/logging/java/JavaLogFactoryTest.java
+++ b/src/test/java/org/owasp/esapi/logging/java/JavaLogFactoryTest.java
@@ -14,12 +14,8 @@
  */
 package org.owasp.esapi.logging.java;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
-import java.util.logging.LogManager;
 
-import org.hamcrest.CustomMatcher;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -28,7 +24,6 @@ import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.owasp.esapi.Logger;
-import org.owasp.esapi.errors.ConfigurationException;
 import org.owasp.esapi.logging.appender.LogAppender;
 import org.owasp.esapi.logging.appender.LogPrefixAppender;
 import org.owasp.esapi.logging.cleaning.CodecLogScrubber;
@@ -47,83 +42,6 @@ public class JavaLogFactoryTest {
 
     @Rule
     public ExpectedException exEx = ExpectedException.none();
-
-    @Test
-    public void testLogManagerConfigurationAsClass() throws Exception {
-        String propKey = "java.util.logging.config.class";
-        //If defined, grab the value; otherwise, set to a known value to allow for prop to be cleared.
-        String sysDefault = System.getProperties().stringPropertyNames().contains(propKey) ? System.getProperty(propKey) : testName.getMethodName();
-
-        System.setProperty(propKey, "some.defined.value");
-        LogManager testLogManager = new LogManager() {
-            @Override
-            public void readConfiguration(InputStream ins) throws IOException, SecurityException {
-                throw new IOException(testName.getMethodName());
-            }
-        };
-
-        try {
-            // This would throw an IOException if the LogManager was not being respected since no esapi-java-logging file is specified
-            JavaLogFactory.readLoggerConfiguration(testLogManager);
-        } finally {
-            //Restore original prop values
-            if (testName.getMethodName().equals(sysDefault))
-                System.clearProperty(propKey);
-            else {
-                System.setProperty(propKey, sysDefault);
-            }
-        }
-    }
-
-    @Test
-    public void testLogManagerConfigurationAsFile() throws Exception {
-        String propKey = "java.util.logging.config.file";
-        //If defined, grab the value; otherwise, set to a known value to allow for prop to be cleared.
-        String sysDefault = System.getProperties().stringPropertyNames().contains(propKey) ? System.getProperty(propKey) : testName.getMethodName();
-
-        System.setProperty(propKey, "some.defined.value");
-        LogManager testLogManager = new LogManager() {
-            @Override
-            public void readConfiguration(InputStream ins) throws IOException, SecurityException {
-                throw new IOException(testName.getMethodName());
-            }
-        };
-
-        try {
-            // This would throw an IOException if the LogManager was not being respected since no esapi-java-logging file is specified
-            JavaLogFactory.readLoggerConfiguration(testLogManager);
-        } finally {
-            //Restore original prop values
-            if (testName.getMethodName().equals(sysDefault)) {
-                System.clearProperty(propKey);
-            } else {
-                System.setProperty(propKey, sysDefault);
-            }
-        }
-    }
-    @Test
-    public void testConfigurationExceptionOnMissingConfiguration() throws Exception {
-        final IOException originException = new IOException(testName.getMethodName());
-
-        LogManager testLogManager = new LogManager() {
-            @Override
-            public void readConfiguration(InputStream ins) throws IOException, SecurityException {
-                throw originException;
-            }
-        };
-
-        exEx.expectMessage("Failed to load esapi-java-logging.properties");
-        exEx.expect(ConfigurationException.class);
-
-        exEx.expectCause(new CustomMatcher<Throwable>("Check for IOException") {
-            @Override
-            public boolean matches(Object item) {
-                return item instanceof IOException;
-            }
-        });
-
-        JavaLogFactory.readLoggerConfiguration(testLogManager);
-    }
 
     @Test
     public void testCreateLoggerByString() {

--- a/src/test/resources/esapi-java-logging.properties
+++ b/src/test/resources/esapi-java-logging.properties
@@ -1,6 +1,0 @@
-handlers= java.util.logging.ConsoleHandler
-.level= INFO
-java.util.logging.ConsoleHandler.level = INFO
-java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
-java.util.logging.SimpleFormatter.format=[%1$tF %1$tT] [%3$-7s] %5$s %n
-#https://www.logicbig.com/tutorials/core-java-tutorial/logging/customizing-default-format.html


### PR DESCRIPTION
Removing support for esapi-java-logging.properties file from baseline.

ConfigurationException is thrown if file is found on the path at runtime.  Exception message links to a wiki page with instructions on how to configure the application instance.

Closes #839 
Also note the wiki page  has been created.
https://github.com/ESAPI/esapi-java-legacy/wiki/Configuring-the-JavaLogFactory