### PR TITLE
Bump to org.apache.commons:commons-configuration2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.jmh>1.37</version.jmh>
-        <version.findsecbugs>2.0.0-M3</version.findsecbugs>
+        <version.findsecbugs>1.13.0</version.findsecbugs>
         <version.fluido>2.0.0-M11</version.fluido>  <!-- 2.0.0 fails on 'mvn site', but this works. -->
         <version.powermock>2.0.9</version.powermock>
         <version.spotbugs>4.8.6</version.spotbugs>
@@ -194,9 +194,9 @@
                  -->
         </dependency>
         <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
-            <version>1.10</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+            <version>2.11.0</version>
             <exclusions>
                 <!-- excluded because multiple dependencies import newer version. -->
                 <exclusion>
@@ -424,6 +424,8 @@
                      </configuration>
                 </plugin>
             </plugins>
+
+
         </pluginManagement>
 
         <plugins>
@@ -706,6 +708,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${version.surefire}</version>
+                <configuration>
+                    <argLine>-Duser.language=en</argLine>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/src/main/java/org/owasp/esapi/reference/accesscontrol/policyloader/ACRParameterLoader.java
+++ b/src/main/java/org/owasp/esapi/reference/accesscontrol/policyloader/ACRParameterLoader.java
@@ -1,6 +1,6 @@
 package org.owasp.esapi.reference.accesscontrol.policyloader;
 
-import org.apache.commons.configuration.XMLConfiguration;
+import org.apache.commons.configuration2.XMLConfiguration;
 
 
 public interface ACRParameterLoader <T> {

--- a/src/main/java/org/owasp/esapi/reference/accesscontrol/policyloader/ACRParameterLoaderHelper.java
+++ b/src/main/java/org/owasp/esapi/reference/accesscontrol/policyloader/ACRParameterLoaderHelper.java
@@ -1,6 +1,6 @@
 package org.owasp.esapi.reference.accesscontrol.policyloader;
 
-import org.apache.commons.configuration.XMLConfiguration;
+import org.apache.commons.configuration2.XMLConfiguration;
 
 final public class ACRParameterLoaderHelper {
 

--- a/src/main/java/org/owasp/esapi/reference/accesscontrol/policyloader/ACRPolicyFileLoader.java
+++ b/src/main/java/org/owasp/esapi/reference/accesscontrol/policyloader/ACRPolicyFileLoader.java
@@ -3,8 +3,13 @@ package org.owasp.esapi.reference.accesscontrol.policyloader;
 import java.io.File;
 import java.util.Collection;
 
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.XMLConfiguration;
+import org.apache.commons.configuration2.XMLConfiguration;
+import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
+import org.apache.commons.configuration2.builder.fluent.Parameters;
+import org.apache.commons.configuration2.convert.DefaultConversionHandler;
+import org.apache.commons.configuration2.convert.DefaultListDelimiterHandler;
+import org.apache.commons.configuration2.convert.ListDelimiterHandler;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.Logger;
 import org.owasp.esapi.errors.AccessControlException;
@@ -18,7 +23,17 @@ final public class ACRPolicyFileLoader {
         File file = ESAPI.securityConfiguration().getResourceFile("ESAPI-AccessControlPolicy.xml");
         try
         {
-            config = new XMLConfiguration(file);
+            FileBasedConfigurationBuilder<XMLConfiguration> builder =
+                    new FileBasedConfigurationBuilder<>(XMLConfiguration.class)
+                            .configure(new Parameters().xml().setFile(file));
+
+            // Preserve compatibility for getStringArray in ACRParameterLoaderHelper
+            ListDelimiterHandler handler = new DefaultListDelimiterHandler(',');
+            DefaultConversionHandler conversionHandler = new DefaultConversionHandler();
+            conversionHandler.setListDelimiterHandler(handler);
+            builder.getConfiguration().setConversionHandler(conversionHandler);
+
+            config = builder.getConfiguration();
         }
         catch(ConfigurationException cex)
         {

--- a/src/main/java/org/owasp/esapi/reference/accesscontrol/policyloader/DynaBeanACRParameterLoader.java
+++ b/src/main/java/org/owasp/esapi/reference/accesscontrol/policyloader/DynaBeanACRParameterLoader.java
@@ -1,6 +1,6 @@
 package org.owasp.esapi.reference.accesscontrol.policyloader;
 
-import org.apache.commons.configuration.XMLConfiguration;
+import org.apache.commons.configuration2.XMLConfiguration;
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.Logger;
 import org.owasp.esapi.reference.accesscontrol.DynaBeanACRParameter;


### PR DESCRIPTION
Bump from commons-configuration:commons-configuration:1.10 to org.apache.commons:commons-configuration2 (fixes many CVEs)