### PR TITLE
Fix guessed release date for 2.6.1.0 to its actual release date.

### DIFF
--- a/documentation/esapi4java-core-2.6.1.0-release-notes.txt
+++ b/documentation/esapi4java-core-2.6.1.0-release-notes.txt
@@ -1,5 +1,5 @@
 Release notes for ESAPI 2.6.1.0
-    Release date: 2025-05-18
+    Release date: 2025-05-19
     Project leaders:
         -Kevin W. Wall <kevin.w.wall@gmail.com>
         -Matt Seil <matt.seil@owasp.org>
@@ -93,7 +93,7 @@ None known, other than the remaining open issues on GitHub.
 
 -----------------------------------------------------------------------------
 
-* Changes since last release 2.6.0.0 and 2.6.1.0, i.e., changes between 2025-11-25 and 2025-05-18.
+* Changes since last release 2.6.0.0 and 2.6.1.0, i.e., changes between 2025-11-25 and 2025-05-19.
 
     Note: I am no longer going to provide the 'Developer Activity Report' that I used to this manually create in tabluar form. This is in part because I use to use 'mvn site' to assist with its creation, but neither the 'Developer Activiity' nor 'File Activity' sections of the 'mvn site' output is currently working.
 

--- a/scripts/vars.2.6.1.0
+++ b/scripts/vars.2.6.1.0
@@ -8,7 +8,7 @@ VERSION=2.6.1.0
 PREV_VERSION=2.6.0.0
 
 # Release date of current version in yyyy-mm-dd format
-YYYY_MM_DD_RELEASE_DATE=2025-05-18
+YYYY_MM_DD_RELEASE_DATE=2025-05-19
 
 # Previous ESAPI release date in same format
 PREV_RELEASE_DATE=2024-11-25


### PR DESCRIPTION
This was to fix up things to reflect reality and was needed since Maven Central took a bit longer than anticipated the last time.

@xeno6696 / @jeremiahjstacey - Note that there will shortly be a 2nd PR following this on a 2.6.2.0 branch as per the usual process.