### PR TITLE
Fixes #894. Remove outdated commons-lang and commons-configuration dependencies with problematic CVEs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,14 +194,18 @@
                  -->
         </dependency>
         <dependency>
-            <groupId>commons-configuration</groupId>
-            <artifactId>commons-configuration</artifactId>
-            <version>1.10</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+            <version>2.12.0</version>
             <exclusions>
-                <!-- excluded because multiple dependencies import newer version. -->
+                <!-- excluded because dependencies import newer versions. -->
                 <exclusion>
                     <groupId>commons-logging</groupId>
                     <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
                 </exclusion>
                 <!-- Note: Because the following dependency is marked as provided to commons-configuration,
                      this exclusion doesn't actually do anything. But we include it so the convergence report
@@ -214,9 +218,23 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.18.0</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.13.1</version>
+            <exclusions>
+                <!-- excluded because it has a CVE, and we've imported the newer version for runtime above. -->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-fileupload</groupId>

--- a/src/main/java/org/owasp/esapi/reference/DefaultSecurityConfiguration.java
+++ b/src/main/java/org/owasp/esapi/reference/DefaultSecurityConfiguration.java
@@ -33,9 +33,8 @@ import java.util.Properties;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.apache.commons.lang.text.StrTokenizer;
+import org.apache.commons.text.StringTokenizer;
 import org.owasp.esapi.ESAPI;
-import org.owasp.esapi.Logger;
 import org.owasp.esapi.PropNames;   // <== Actual property names moved to here. Eventually we'll do static import.
 import org.owasp.esapi.PropNames.DefaultSearchPath;
 import org.owasp.esapi.SecurityConfiguration;
@@ -651,7 +650,7 @@ public class DefaultSecurityConfiguration implements SecurityConfiguration {
 
             if(multivalued){
                 // the following cast warning goes away if the apache commons lib is updated to current version
-                validationPropFileNames = StrTokenizer.getCSVInstance(validationPropValue);
+                validationPropFileNames = StringTokenizer.getCSVInstance(validationPropValue);
             } else {
                 validationPropFileNames = Collections.singletonList(validationPropValue).iterator();
             }

--- a/src/main/java/org/owasp/esapi/reference/accesscontrol/policyloader/ACRParameterLoader.java
+++ b/src/main/java/org/owasp/esapi/reference/accesscontrol/policyloader/ACRParameterLoader.java
@@ -1,6 +1,6 @@
 package org.owasp.esapi.reference.accesscontrol.policyloader;
 
-import org.apache.commons.configuration.XMLConfiguration;
+import org.apache.commons.configuration2.XMLConfiguration;
 
 
 public interface ACRParameterLoader <T> {

--- a/src/main/java/org/owasp/esapi/reference/accesscontrol/policyloader/ACRParameterLoaderHelper.java
+++ b/src/main/java/org/owasp/esapi/reference/accesscontrol/policyloader/ACRParameterLoaderHelper.java
@@ -1,6 +1,6 @@
 package org.owasp.esapi.reference.accesscontrol.policyloader;
 
-import org.apache.commons.configuration.XMLConfiguration;
+import org.apache.commons.configuration2.XMLConfiguration;
 
 final public class ACRParameterLoaderHelper {
 

--- a/src/main/java/org/owasp/esapi/reference/accesscontrol/policyloader/DynaBeanACRParameterLoader.java
+++ b/src/main/java/org/owasp/esapi/reference/accesscontrol/policyloader/DynaBeanACRParameterLoader.java
@@ -1,6 +1,6 @@
 package org.owasp.esapi.reference.accesscontrol.policyloader;
 
-import org.apache.commons.configuration.XMLConfiguration;
+import org.apache.commons.configuration2.XMLConfiguration;
 import org.owasp.esapi.ESAPI;
 import org.owasp.esapi.Logger;
 import org.owasp.esapi.reference.accesscontrol.DynaBeanACRParameter;


### PR DESCRIPTION
I updated the dependency-check-maven plugin version locally to 12.1.1 and ran with a later JDK to confirm no other CVEs were detected.