### PR TITLE
Patch CVE-2025-48924 : commons-lang:2.6 to commons-lang3:3.19.0

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,7 +5,6 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ develop ]
   pull_request:
     branches: [ develop ]
 

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.jmh>1.37</version.jmh>
-        <version.findsecbugs>2.0.0-M3</version.findsecbugs>
+        <version.findsecbugs>1.14.0</version.findsecbugs>
         <version.fluido>2.0.0-M11</version.fluido>  <!-- Version 2.1.0 is available, but fails with this min Maven. -->
         <version.powermock>2.0.9</version.powermock>
         <version.spotbugs>4.9.3</version.spotbugs>
@@ -214,9 +214,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.19.0</version>
         </dependency>
         <dependency>
             <groupId>commons-fileupload</groupId>
@@ -759,6 +759,8 @@
                 <version>10.0.4</version>
                 <configuration>
                     <nvdApiKey>${env.NVD_API_KEY}</nvdApiKey>
+                    <ossIndexUsername>${env.OSS_INDEX_USERNAME}</ossIndexUsername>
+                    <ossIndexPassword>${env.OSS_INDEX_PASSWORD}</ossIndexPassword>
                     <failBuildOnCVSS>1.0</failBuildOnCVSS>
                     <suppressionFiles>./suppressions.xml</suppressionFiles>
                 </configuration>


### PR DESCRIPTION
Also updated 
 - Allow github actions to build on all push commits
 - findsecbugs 2.0.0-M3 to 1.14.0 (public version) as 2.0.0-M3 does not seem publicly available when i was compiling/searching
 - Included extra owasp vars which is now required for [sonatype login](https://ossindex.sonatype.org) auth 
 ```
     <ossIndexUsername>${env.OSS_INDEX_USERNAME}</ossIndexUsername>
     <ossIndexPassword>${env.OSS_INDEX_PASSWORD}</ossIndexPassword>
```

Move from legacy commons-lang 2.6 to commons-lang3 3.19.0 to remove this cve:

CVE-2025-48924 (OSSINDEX)  suppress

Uncontrolled Recursion vulnerability in Apache Commons Lang.

This issue affects Apache Commons Lang: Starting with commons-lang:commons-lang 2.0 to 2.6, and, from org.apache.commons:commons-lang3 3.0 before 3.18.0.

The methods ClassUtils.getClass(...) can throw StackOverflowError on very long inputs. Because an Error is usually not handled by applications and libraries, a 
StackOverflowError could cause an application to stop.

Users are recommended to upgrade to version 3.18.0, which fixes the issue.

Sonatype's research suggests that this CVE's details differ from those defined at NVD. See https://ossindex.sonatype.org/vulnerability/CVE-2025-48924 for details
CWE-674 Uncontrolled Recursion

CVSSv2:
Base Score: MEDIUM (6.900000095367432)
Vector: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N

References:
OSSINDEX - [[CVE-2025-48924] CWE-674: Uncontrolled Recursion](https://ossindex.sonatype.org/vulnerability/CVE-2025-48924?component-type=maven&component-name=commons-lang%2Fcommons-lang&utm_source=dependency-check&utm_medium=integration&utm_content=12.1.3)
OSSIndex - http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2025-48924
OSSIndex - https://github.com/advisories/GHSA-j288-q9x7-2f5v
Vulnerable Software & Versions (OSSINDEX):

cpe:2.3:a:commons-lang:commons-lang:2.6:*:*:*:*:*:*:*