### PR TITLE
Fix predictable marker collision in EncodingPatternPreservation

### DIFF
--- a/src/main/java/org/owasp/esapi/codecs/ref/EncodingPatternPreservation.java
+++ b/src/main/java/org/owasp/esapi/codecs/ref/EncodingPatternPreservation.java
@@ -2,6 +2,7 @@ package org.owasp.esapi.codecs.ref;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -12,12 +13,35 @@ import java.util.regex.Pattern;
  *
  */
 public class EncodingPatternPreservation {
-    /** Default replacement marker. */
-    private static final String REPLACEMENT_MARKER = EncodingPatternPreservation.class.getSimpleName();
     /** Pattern that is used to identify which content should be replaced. */
     private final Pattern noEncodeContent;
-    /** The Marker used to replace found Pattern references. */
-    private String replacementMarker = REPLACEMENT_MARKER;
+    /**
+     * The Marker used to replace found Pattern references. Defaults to a
+     * per-instance random value so that input content cannot collide with it;
+     * see {@link #captureAndReplaceMatches(String)}.
+     */
+    private String replacementMarker = defaultReplacementMarker();
+
+    /**
+     * Builds an unpredictable default marker. Using a fixed, publicly-known
+     * marker (e.g. this class's simple name) would let an attacker embed that
+     * literal string in the input ahead of real matched content; since
+     * {@link #restoreOriginalContent(String)} replaces markers in encounter
+     * order via {@code replaceFirst}, that attacker-supplied marker would be
+     * replaced first, desynchronizing every subsequent restoration.
+     * <p>
+     * The marker is kept purely alphanumeric (no hyphens) because callers
+     * such as {@link org.owasp.esapi.codecs.CSSCodec} run an encoding pass
+     * over the marker before it is restored; a hyphen would itself be
+     * escaped by that pass, breaking the exact-match lookup in
+     * {@link #restoreOriginalContent(String)}.
+     *
+     * @return A marker string that is not derivable from public information.
+     */
+    private static String defaultReplacementMarker() {
+        return EncodingPatternPreservation.class.getSimpleName()
+                + UUID.randomUUID().toString().replace("-", "");
+    }
 
     /**
      * The ordered-list of elements that were replaced in the last call to

--- a/src/test/java/org/owasp/esapi/codecs/ref/EncodingPatternPreservationTest.java
+++ b/src/test/java/org/owasp/esapi/codecs/ref/EncodingPatternPreservationTest.java
@@ -15,7 +15,9 @@ public class EncodingPatternPreservationTest {
         String origStr = "12 ABC 34 DEF 56 G 7";
         String replacedStr = epp.captureAndReplaceMatches(origStr);
 
-        assertEquals("12 EncodingPatternPreservation 34 DEF 56 G 7", replacedStr);
+        assertFalse("Replaced string should no longer contain the matched pattern", replacedStr.contains("ABC"));
+        assertTrue(replacedStr.startsWith("12 EncodingPatternPreservation"));
+        assertTrue(replacedStr.endsWith(" 34 DEF 56 G 7"));
 
         String restored = epp.restoreOriginalContent(replacedStr);
         assertEquals(origStr, restored);
@@ -28,9 +30,38 @@ public class EncodingPatternPreservationTest {
         String origStr = "12 ABC 34 ABC 56 G 7 ABC8";
         String replacedStr = epp.captureAndReplaceMatches(origStr);
 
-        assertEquals("12 EncodingPatternPreservation 34 EncodingPatternPreservation 56 G 7 EncodingPatternPreservation8", replacedStr);
+        assertFalse("Replaced string should no longer contain the matched pattern", replacedStr.contains("ABC"));
 
         String restored = epp.restoreOriginalContent(replacedStr);
+        assertEquals(origStr, restored);
+    }
+
+    @Test
+    public void testDefaultMarkerIsUnpredictablePerInstance() {
+        Pattern numberRegex = Pattern.compile("(ABC)");
+        EncodingPatternPreservation epp1 = new EncodingPatternPreservation(numberRegex);
+        EncodingPatternPreservation epp2 = new EncodingPatternPreservation(numberRegex);
+
+        String replaced1 = epp1.captureAndReplaceMatches("ABC");
+        String replaced2 = epp2.captureAndReplaceMatches("ABC");
+
+        assertNotEquals("Default marker must not be a fixed, guessable value shared across instances",
+                replaced1, replaced2);
+    }
+
+    @Test
+    public void testInputContainingLiteralClassNameDoesNotDesyncRestoration() {
+        // Regression test: previously the default marker was the fixed literal
+        // "EncodingPatternPreservation", so input already containing that literal
+        // string ahead of real matched content would be restored in place of the
+        // real match, desynchronizing every subsequent restoreFirst() call.
+        Pattern numberRegex = Pattern.compile("(ABC)");
+        EncodingPatternPreservation epp = new EncodingPatternPreservation(numberRegex);
+        String origStr = "EncodingPatternPreservation prefix ABC suffix";
+
+        String replacedStr = epp.captureAndReplaceMatches(origStr);
+        String restored = epp.restoreOriginalContent(replacedStr);
+
         assertEquals(origStr, restored);
     }
 


### PR DESCRIPTION
## Summary

`EncodingPatternPreservation` (used by `CSSCodec` to protect `rgb(...)` triplets from CSS-escaping during `encodeForCSS`) previously used a fixed, publicly-known default marker: this class's own simple name, `"EncodingPatternPreservation"`.

`captureAndReplaceMatches()` temporarily swaps matched content for this marker; `restoreOriginalContent()` restores it afterwards using `replaceFirst(marker, ...)`, matching the marker as **plain literal text**, in FIFO order.

Because the marker is a known constant, input that already contains that literal string *ahead of* real matched content causes `replaceFirst` to match the attacker-supplied text instead of the real placeholder. Every subsequent restoration in the same call is then shifted by one, silently corrupting the output — restored content ends up in the wrong position (or is left as a raw, unrestored marker string).

Minimal repro:

```java
Pattern rgb = Pattern.compile("([rR][gG][bB])\\s*\\(\\s*\\d{1,3}\\s*,\\s*\\d{1,3}\\s*,\\s*\\d{1,3}\\s*\\)");
EncodingPatternPreservation epp = new EncodingPatternPreservation(rgb);

String input = "EncodingPatternPreservation color:rgb(1,2,3);";
String replaced = epp.captureAndReplaceMatches(input);
// replaced == "EncodingPatternPreservation color:EncodingPatternPreservation;"

String restored = epp.restoreOriginalContent(replaced);
// restored == "rgb(1,2,3) color:EncodingPatternPreservation;"   (WRONG — desynced)
// expected == "EncodingPatternPreservation color:rgb(1,2,3);"
```

I want to be precise about severity: I checked whether this is exploitable as an injection/XSS primitive and don't believe it is — the only regex currently fed through this class (`CSSCodec`'s RGB-triplet pattern) can only ever capture digits, `%`, commas, whitespace and `rgb(`/`)`, so a desynchronized restore can't smuggle unexpected characters through `encodeForCSS()`. This is an **output-integrity bug** (silently wrong/corrupted encoder output), not a bypass of the encoding itself.

## Fix

Derive the default marker per-instance from a random UUID instead of a fixed literal, so it can't be predicted or pre-supplied in input. Hyphens are stripped from the UUID because a hyphen would itself be altered by an encoding pass (e.g. `CSSCodec.encode()` backslash-escapes non-immune characters) before `restoreOriginalContent()` runs, which would break the exact-match lookup — I hit this while writing the fix and confirmed it against the existing `CSSCodecTest` suite. The public `setReplacementMarker()` API is unchanged for callers who want to supply their own marker.

## Test plan

- [x] Added `testDefaultMarkerIsUnpredictablePerInstance` — two instances never produce the same default marker.
- [x] Added `testInputContainingLiteralClassNameDoesNotDesyncRestoration` — regression test reproducing the exact scenario above.
- [x] Updated the two existing tests that asserted on the old fixed-marker string, to assert on the marker's presence/shape instead.
- [x] `mvn -Dtest=EncodingPatternPreservationTest,CSSCodecTest test` — 11/11 pass.
- [x] Full `mvn test` — pass, no other suite affected.