### PR TITLE
Clean up obsolete ESAPI 1.4 comments in config files #474

### DIFF
--- a/src/main/java/org/owasp/esapi/SecurityConfiguration.java
+++ b/src/main/java/org/owasp/esapi/SecurityConfiguration.java
@@ -239,10 +239,9 @@ public interface SecurityConfiguration extends EsapiPropertyLoader {
     String getUsernameParameterName();
 
     /**
-     * Gets the encryption algorithm used by ESAPI to protect data. This is
-     * mostly used for compatibility with ESAPI 1.4; ESAPI 2.0 prefers to
-     * use "cipher transformation" since it supports multiple cipher modes
-     * and padding schemes.
+     * Gets the encryption algorithm used by ESAPI to protect data.
+     * ESAPI 2.x prefers to use "cipher transformation" since it supports
+     * multiple cipher modes and padding schemes.
      *
      * @return the current encryption algorithm
      * @deprecated Use SecurityConfiguration.getStringProp("appropriate_esapi_prop_name") instead.
@@ -271,8 +270,8 @@ public interface SecurityConfiguration extends EsapiPropertyLoader {
      * </p><p>
      * Examples are:
      * <pre>
-     *         "AES/ECB/NoPadding"        // Default for ESAPI Java 1.4 (insecure)
-     *         "AES/CBC/PKCS5Padding"    // Default for ESAPI Java 2.0
+     *         "AES/ECB/NoPadding"        // Insecure; do not use
+     *         "AES/CBC/PKCS5Padding"    // Default for ESAPI 2.x
      *         "DESede/OFB32/PKCS5Padding"
      * </pre>
      * <b>NOTE:</b> Occasionally, in cryptographic literature, you may also

--- a/src/test/resources/esapi/ESAPI-CommaValidatorFileChecker.properties
+++ b/src/test/resources/esapi/ESAPI-CommaValidatorFileChecker.properties
@@ -63,12 +63,6 @@
 # get updated dynamically.
 #
 # Before using, be sure to update the MasterKey and MasterSalt as described below.
-# N.B.: If you had stored data that you have previously encrypted with ESAPI 1.4,
-#		you *must* FIRST decrypt it using ESAPI 1.4 and then (if so desired)
-#		re-encrypt it with ESAPI 2.0. If you fail to do this, you will NOT be
-#		able to decrypt your data with ESAPI 2.0.
-#
-#		YOU HAVE BEEN WARNED!!! More details are in the ESAPI 2.0 Release Notes.
 #
 #===========================================================================
 # ESAPI Configuration
@@ -158,21 +152,6 @@ Encoder.DefaultCodecList=HTMLEntityCodec,PercentCodec,JavaScriptCodec
 # unlimited strength policy files and install in the lib directory of your JRE/JDK.
 # See http://java.sun.com/javase/downloads/index.jsp for more information.
 #
-# Backward compatibility with ESAPI Java 1.4 is supported by the two deprecated API
-# methods, Encryptor.encrypt(String) and Encryptor.decrypt(String). However, whenever
-# possible, these methods should be avoided as they use ECB cipher mode, which in almost
-# all circumstances a poor choice because of it's weakness. CBC cipher mode is the default
-# for the new Encryptor encrypt / decrypt methods for ESAPI Java 2.0.  In general, you
-# should only use this compatibility setting if you have persistent data encrypted with
-# version 1.4 and even then, you should ONLY set this compatibility mode UNTIL
-# you have decrypted all of your old encrypted data and then re-encrypted it with
-# ESAPI 2.0 using CBC mode. If you have some reason to mix the deprecated 1.4 mode
-# with the new 2.0 methods, make sure that you use the same cipher algorithm for both
-# (256-bit AES was the default for 1.4; 128-bit is the default for 2.0; see below for
-# more details.) Otherwise, you will have to use the new 2.0 encrypt / decrypt methods
-# where you can specify a SecretKey. (Note that if you are using the 256-bit AES,
-# that requires downloading the special jurisdiction policy files mentioned above.)
-#
 #		***** IMPORTANT: These are for JUnit testing. Test files may have been
 #						 encrypted using these values so do not change these or
 #						 those tests will fail. The version under
@@ -219,12 +198,6 @@ Encryptor.PreferredJCEProvider=
 
 # AES is the most widely used and strongest encryption algorithm. This
 # should agree with your Encryptor.CipherTransformation property.
-# By default, ESAPI Java 1.4 uses "PBEWithMD5AndDES" and which is
-# very weak. It is essentially a password-based encryption key, hashed
-# with MD5 around 1K times and then encrypted with the weak DES algorithm
-# (56-bits) using ECB mode and an unspecified padding (it is
-# JCE provider specific, but most likely "NoPadding"). However, 2.0 uses
-# "AES/CBC/PKCSPadding". If you want to change these, change them here.
 # Warning: This property does not control the default reference implementation for
 #		   ESAPI 2.0 using JavaEncryptor. Also, this property will be dropped
 #		   in the future.
@@ -273,7 +246,6 @@ Encryptor.cipher_modes.additional_allowed=CBC,ECB
 # cipher transformation, otherwise this will be ignored after logging a
 # warning.
 #
-# NOTE: This is what applies BOTH ESAPI 1.4 and 2.0. See warning above about mixing!
 Encryptor.EncryptionKeyLength=128
 # Min key length - to support testing with 2TDEA
 Encryptor.MinEncryptionKeyLength=112

--- a/src/test/resources/esapi/ESAPI-DualValidatorFileChecker.properties
+++ b/src/test/resources/esapi/ESAPI-DualValidatorFileChecker.properties
@@ -63,12 +63,6 @@
 # get updated dynamically.
 #
 # Before using, be sure to update the MasterKey and MasterSalt as described below.
-# N.B.: If you had stored data that you have previously encrypted with ESAPI 1.4,
-#		you *must* FIRST decrypt it using ESAPI 1.4 and then (if so desired)
-#		re-encrypt it with ESAPI 2.0. If you fail to do this, you will NOT be
-#		able to decrypt your data with ESAPI 2.0.
-#
-#		YOU HAVE BEEN WARNED!!! More details are in the ESAPI 2.0 Release Notes.
 #
 #===========================================================================
 # ESAPI Configuration
@@ -158,21 +152,6 @@ Encoder.DefaultCodecList=HTMLEntityCodec,PercentCodec,JavaScriptCodec
 # unlimited strength policy files and install in the lib directory of your JRE/JDK.
 # See http://java.sun.com/javase/downloads/index.jsp for more information.
 #
-# Backward compatibility with ESAPI Java 1.4 is supported by the two deprecated API
-# methods, Encryptor.encrypt(String) and Encryptor.decrypt(String). However, whenever
-# possible, these methods should be avoided as they use ECB cipher mode, which in almost
-# all circumstances a poor choice because of it's weakness. CBC cipher mode is the default
-# for the new Encryptor encrypt / decrypt methods for ESAPI Java 2.0.  In general, you
-# should only use this compatibility setting if you have persistent data encrypted with
-# version 1.4 and even then, you should ONLY set this compatibility mode UNTIL
-# you have decrypted all of your old encrypted data and then re-encrypted it with
-# ESAPI 2.0 using CBC mode. If you have some reason to mix the deprecated 1.4 mode
-# with the new 2.0 methods, make sure that you use the same cipher algorithm for both
-# (256-bit AES was the default for 1.4; 128-bit is the default for 2.0; see below for
-# more details.) Otherwise, you will have to use the new 2.0 encrypt / decrypt methods
-# where you can specify a SecretKey. (Note that if you are using the 256-bit AES,
-# that requires downloading the special jurisdiction policy files mentioned above.)
-#
 #		***** IMPORTANT: These are for JUnit testing. Test files may have been
 #						 encrypted using these values so do not change these or
 #						 those tests will fail. The version under
@@ -219,12 +198,6 @@ Encryptor.PreferredJCEProvider=
 
 # AES is the most widely used and strongest encryption algorithm. This
 # should agree with your Encryptor.CipherTransformation property.
-# By default, ESAPI Java 1.4 uses "PBEWithMD5AndDES" and which is
-# very weak. It is essentially a password-based encryption key, hashed
-# with MD5 around 1K times and then encrypted with the weak DES algorithm
-# (56-bits) using ECB mode and an unspecified padding (it is
-# JCE provider specific, but most likely "NoPadding"). However, 2.0 uses
-# "AES/CBC/PKCSPadding". If you want to change these, change them here.
 # Warning: This property does not control the default reference implementation for
 #		   ESAPI 2.0 using JavaEncryptor. Also, this property will be dropped
 #		   in the future.
@@ -273,7 +246,6 @@ Encryptor.cipher_modes.additional_allowed=CBC,ECB
 # cipher transformation, otherwise this will be ignored after logging a
 # warning.
 #
-# NOTE: This is what applies BOTH ESAPI 1.4 and 2.0. See warning above about mixing!
 Encryptor.EncryptionKeyLength=128
 
 # Min key length - to support testing with 2TDEA

--- a/src/test/resources/esapi/ESAPI-QuotedValidatorFileChecker.properties
+++ b/src/test/resources/esapi/ESAPI-QuotedValidatorFileChecker.properties
@@ -62,12 +62,6 @@
 # get updated dynamically.
 #
 # Before using, be sure to update the MasterKey and MasterSalt as described below.
-# N.B.: If you had stored data that you have previously encrypted with ESAPI 1.4,
-#		you *must* FIRST decrypt it using ESAPI 1.4 and then (if so desired)
-#		re-encrypt it with ESAPI 2.0. If you fail to do this, you will NOT be
-#		able to decrypt your data with ESAPI 2.0.
-#
-#		YOU HAVE BEEN WARNED!!! More details are in the ESAPI 2.0 Release Notes.
 #
 #===========================================================================
 # ESAPI Configuration
@@ -157,21 +151,6 @@ Encoder.DefaultCodecList=HTMLEntityCodec,PercentCodec,JavaScriptCodec
 # unlimited strength policy files and install in the lib directory of your JRE/JDK.
 # See http://java.sun.com/javase/downloads/index.jsp for more information.
 #
-# Backward compatibility with ESAPI Java 1.4 is supported by the two deprecated API
-# methods, Encryptor.encrypt(String) and Encryptor.decrypt(String). However, whenever
-# possible, these methods should be avoided as they use ECB cipher mode, which in almost
-# all circumstances a poor choice because of it's weakness. CBC cipher mode is the default
-# for the new Encryptor encrypt / decrypt methods for ESAPI Java 2.0.  In general, you
-# should only use this compatibility setting if you have persistent data encrypted with
-# version 1.4 and even then, you should ONLY set this compatibility mode UNTIL
-# you have decrypted all of your old encrypted data and then re-encrypted it with
-# ESAPI 2.0 using CBC mode. If you have some reason to mix the deprecated 1.4 mode
-# with the new 2.0 methods, make sure that you use the same cipher algorithm for both
-# (256-bit AES was the default for 1.4; 128-bit is the default for 2.0; see below for
-# more details.) Otherwise, you will have to use the new 2.0 encrypt / decrypt methods
-# where you can specify a SecretKey. (Note that if you are using the 256-bit AES,
-# that requires downloading the special jurisdiction policy files mentioned above.)
-#
 #		***** IMPORTANT: These are for JUnit testing. Test files may have been
 #						 encrypted using these values so do not change these or
 #						 those tests will fail. The version under
@@ -218,12 +197,6 @@ Encryptor.PreferredJCEProvider=
 
 # AES is the most widely used and strongest encryption algorithm. This
 # should agree with your Encryptor.CipherTransformation property.
-# By default, ESAPI Java 1.4 uses "PBEWithMD5AndDES" and which is
-# very weak. It is essentially a password-based encryption key, hashed
-# with MD5 around 1K times and then encrypted with the weak DES algorithm
-# (56-bits) using ECB mode and an unspecified padding (it is
-# JCE provider specific, but most likely "NoPadding"). However, 2.0 uses
-# "AES/CBC/PKCSPadding". If you want to change these, change them here.
 # Warning: This property does not control the default reference implementation for
 #		   ESAPI 2.0 using JavaEncryptor. Also, this property will be dropped
 #		   in the future.
@@ -272,7 +245,6 @@ Encryptor.cipher_modes.additional_allowed=CBC,ECB
 # cipher transformation, otherwise this will be ignored after logging a
 # warning.
 #
-# NOTE: This is what applies BOTH ESAPI 1.4 and 2.0. See warning above about mixing!
 Encryptor.EncryptionKeyLength=128
 # Min key length - to support testing with 2TDEA
 Encryptor.MinEncryptionKeyLength=112

--- a/src/test/resources/esapi/ESAPI-SingleValidatorFileChecker.properties
+++ b/src/test/resources/esapi/ESAPI-SingleValidatorFileChecker.properties
@@ -62,12 +62,6 @@
 # get updated dynamically.
 #
 # Before using, be sure to update the MasterKey and MasterSalt as described below.
-# N.B.: If you had stored data that you have previously encrypted with ESAPI 1.4,
-#		you *must* FIRST decrypt it using ESAPI 1.4 and then (if so desired)
-#		re-encrypt it with ESAPI 2.0. If you fail to do this, you will NOT be
-#		able to decrypt your data with ESAPI 2.0.
-#
-#		YOU HAVE BEEN WARNED!!! More details are in the ESAPI 2.0 Release Notes.
 #
 #===========================================================================
 # ESAPI Configuration
@@ -157,21 +151,6 @@ Encoder.DefaultCodecList=HTMLEntityCodec,PercentCodec,JavaScriptCodec
 # unlimited strength policy files and install in the lib directory of your JRE/JDK.
 # See http://java.sun.com/javase/downloads/index.jsp for more information.
 #
-# Backward compatibility with ESAPI Java 1.4 is supported by the two deprecated API
-# methods, Encryptor.encrypt(String) and Encryptor.decrypt(String). However, whenever
-# possible, these methods should be avoided as they use ECB cipher mode, which in almost
-# all circumstances a poor choice because of it's weakness. CBC cipher mode is the default
-# for the new Encryptor encrypt / decrypt methods for ESAPI Java 2.0.  In general, you
-# should only use this compatibility setting if you have persistent data encrypted with
-# version 1.4 and even then, you should ONLY set this compatibility mode UNTIL
-# you have decrypted all of your old encrypted data and then re-encrypted it with
-# ESAPI 2.0 using CBC mode. If you have some reason to mix the deprecated 1.4 mode
-# with the new 2.0 methods, make sure that you use the same cipher algorithm for both
-# (256-bit AES was the default for 1.4; 128-bit is the default for 2.0; see below for
-# more details.) Otherwise, you will have to use the new 2.0 encrypt / decrypt methods
-# where you can specify a SecretKey. (Note that if you are using the 256-bit AES,
-# that requires downloading the special jurisdiction policy files mentioned above.)
-#
 #		***** IMPORTANT: These are for JUnit testing. Test files may have been
 #						 encrypted using these values so do not change these or
 #						 those tests will fail. The version under
@@ -218,12 +197,6 @@ Encryptor.PreferredJCEProvider=
 
 # AES is the most widely used and strongest encryption algorithm. This
 # should agree with your Encryptor.CipherTransformation property.
-# By default, ESAPI Java 1.4 uses "PBEWithMD5AndDES" and which is
-# very weak. It is essentially a password-based encryption key, hashed
-# with MD5 around 1K times and then encrypted with the weak DES algorithm
-# (56-bits) using ECB mode and an unspecified padding (it is
-# JCE provider specific, but most likely "NoPadding"). However, 2.0 uses
-# "AES/CBC/PKCSPadding". If you want to change these, change them here.
 # Warning: This property does not control the default reference implementation for
 #		   ESAPI 2.0 using JavaEncryptor. Also, this property will be dropped
 #		   in the future.
@@ -272,7 +245,6 @@ Encryptor.cipher_modes.additional_allowed=CBC,ECB
 # cipher transformation, otherwise this will be ignored after logging a
 # warning.
 #
-# NOTE: This is what applies BOTH ESAPI 1.4 and 2.0. See warning above about mixing!
 Encryptor.EncryptionKeyLength=128
 # Min key length - to support testing with 2TDEA
 Encryptor.MinEncryptionKeyLength=112

--- a/src/test/resources/esapi/ESAPI.properties
+++ b/src/test/resources/esapi/ESAPI.properties
@@ -199,12 +199,6 @@ Encryptor.PreferredJCEProvider=
 
 # AES is the most widely used and strongest encryption algorithm. This
 # should agree with your Encryptor.CipherTransformation property.
-# By default, ESAPI Java 1.4 uses "PBEWithMD5AndDES" and which is
-# very weak. It is essentially a password-based encryption key, hashed
-# with MD5 around 1K times and then encrypted with the weak DES algorithm
-# (56-bits) using ECB mode and an unspecified padding (it is
-# JCE provider specific, but most likely "NoPadding"). However, 2.0 uses
-# "AES/CBC/PKCSPadding". If you want to change these, change them here.
 # Warning: This property does not control the default reference implementation for
 #		   ESAPI 2.0 using JavaEncryptor. Also, this property will be dropped
 #		   in the future.


### PR DESCRIPTION
I dropped the leftover ESAPI 1.4 comments from the ESAPI.properties copies used in tests. Those notes still described decrypting with 1.4 and the old encrypt(String)/decrypt(String) methods, which are gone. The production configuration file was already clean.

Also updated the matching javadoc on SecurityConfiguration.

Fixes #474
